### PR TITLE
feat: add Postgres-backed MusicBrainz client (MusicBrainzDB)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,22 @@
+# Benchmarks
+
+Postgres (local MusicBrainz mirror) vs Public API.
+
+## 2026-04-01 00:32
+
+| Query | API | Postgres | Speedup |
+|-------|-----|----------|---------|
+| 25 single lookups | 43.526s | 24.888s | 2x |
+| 25-MBID batch | 1.160s | 0.931s | 1x |
+| 5 artist rels | 6.313s | 2.331s | 3x |
+| **TOTAL** | **50.999s** | **28.150s** | **2x** |
+
+## 2026-04-01 00:43
+
+| Query | API | Postgres | Speedup |
+|-------|-----|----------|---------|
+| 4 single lookups | 7.757s | 5.073s | 2x |
+| 4-MBID batch | 1.749s | 0.972s | 2x |
+| 5 artist rels | 5.816s | 2.106s | 3x |
+| **TOTAL** | **15.322s** | **8.151s** | **2x** |
+

--- a/modules/module2/pyproject.toml
+++ b/modules/module2/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Beam search path finding for playlist generation"
 readme = "README.md"
 requires-python = ">=3.13"
-dependencies = ["requests>=2.31.0", "module1"]
+dependencies = ["requests>=2.31.0", "module1", "psycopg[pool,binary]>=3.1"]
 
 [tool.uv.sources]
 module1 = { workspace = true }

--- a/modules/module2/src/module2/__init__.py
+++ b/modules/module2/src/module2/__init__.py
@@ -31,6 +31,7 @@ from .beam_search import BeamSearch
 from .data_models import PlaylistPath, SearchState, SimilarRecording
 from .listenbrainz_client import ListenBrainzClient, ListenBrainzConfig
 from .musicbrainz_client import MusicBrainzClient, MusicBrainzConfig
+from .musicbrainz_db import MusicBrainzDB, MusicBrainzDBConfig
 from .search_space import SearchSpace, SearchSpaceProtocol
 
 __all__ = [
@@ -49,4 +50,7 @@ __all__ = [
     "AcousticBrainzConfig",
     "MusicBrainzClient",
     "MusicBrainzConfig",
+    # Postgres-backed client
+    "MusicBrainzDB",
+    "MusicBrainzDBConfig",
 ]

--- a/modules/module2/src/module2/musicbrainz_db.py
+++ b/modules/module2/src/module2/musicbrainz_db.py
@@ -1,0 +1,297 @@
+"""MusicBrainz Postgres client — direct database queries, no rate limits.
+
+Drop-in replacement for MusicBrainzClient. Same interface, same return types,
+but queries a local MusicBrainz mirror via psycopg + connection pool instead
+of the REST API.
+
+Connection configurable via MusicBrainzDBConfig or MB_DB_* environment variables.
+Requires ~/.pgpass for passwordless auth.
+
+Usage:
+    # Uses env vars / defaults
+    db = MusicBrainzDB()
+    meta = db.get_recording_metadata("1eac49da-3399-4d34-bbf3-a98a91e2758b")
+
+    # Custom config
+    db = MusicBrainzDB(MusicBrainzDBConfig(host="10.0.0.5", schema="canonical"))
+
+    # Context manager (auto-closes pool)
+    with MusicBrainzDB() as db:
+        meta = db.get_recording_metadata(mbid)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+
+from psycopg_pool import ConnectionPool
+
+from .musicbrainz_client import RecordingMetadata
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+
+@dataclass
+class MusicBrainzDBConfig:
+    """Configuration for direct Postgres connection.
+
+    All fields can be overridden via environment variables (MB_DB_*) or
+    passed directly. Password is read from ~/.pgpass — never stored here.
+    """
+
+    host: str = ""
+    port: int = 0
+    dbname: str = ""
+    user: str = ""
+    schema: str = ""
+
+    # Connection pool sizing
+    pool_min: int = 1
+    pool_max: int = 5
+
+    def __post_init__(self):
+        self.host = self.host or os.environ.get("MB_DB_HOST", "localhost")
+        self.port = self.port or int(os.environ.get("MB_DB_PORT", "5432"))
+        self.dbname = self.dbname or os.environ.get("MB_DB_NAME", "musicbrainz")
+        self.user = self.user or os.environ.get("MB_DB_USER", "musicbrainz")
+        self.schema = self.schema or os.environ.get("MB_DB_SCHEMA", "musicbrainz")
+
+    @property
+    def conninfo(self) -> str:
+        """Build psycopg connection string (password via ~/.pgpass)."""
+        return (
+            f"host={self.host} port={self.port} dbname={self.dbname} user={self.user}"
+        )
+
+
+# =============================================================================
+# SQL Queries — parameterized, schema-prefixed
+# =============================================================================
+
+
+def _q(schema: str) -> dict[str, str]:
+    """Build all SQL queries with the configured schema prefix."""
+    s = schema
+
+    return {
+        "recording_single": f"""\
+            SELECT
+                a.gid::text    AS artist_mbid,
+                rfrd.year      AS release_year,
+                array_agg(DISTINCT g.name) FILTER (WHERE g.name IS NOT NULL) AS genres
+            FROM {s}.recording r
+            JOIN {s}.artist_credit_name acn ON r.artist_credit = acn.artist_credit
+            JOIN {s}.artist a ON acn.artist = a.id
+            LEFT JOIN {s}.recording_first_release_date rfrd ON r.id = rfrd.recording
+            LEFT JOIN {s}.recording_tag rt ON r.id = rt.recording
+            LEFT JOIN {s}.genre g ON rt.tag = g.id
+            WHERE r.gid = %s
+            GROUP BY a.gid, rfrd.year
+            LIMIT 1
+        """,
+        "recording_batch": f"""\
+            SELECT
+                r.gid::text    AS recording_mbid,
+                a.gid::text    AS artist_mbid,
+                rfrd.year      AS release_year,
+                array_agg(DISTINCT g.name) FILTER (WHERE g.name IS NOT NULL) AS genres
+            FROM {s}.recording r
+            JOIN {s}.artist_credit_name acn ON r.artist_credit = acn.artist_credit
+            JOIN {s}.artist a ON acn.artist = a.id
+            LEFT JOIN {s}.recording_first_release_date rfrd ON r.id = rfrd.recording
+            LEFT JOIN {s}.recording_tag rt ON r.id = rt.recording
+            LEFT JOIN {s}.genre g ON rt.tag = g.id
+            WHERE r.gid = ANY(%s)
+            GROUP BY r.gid, a.gid, rfrd.year
+        """,
+        "artist_rels": f"""\
+            SELECT a2.gid::text
+            FROM {s}.l_artist_artist laa
+            JOIN {s}.artist a1 ON laa.entity0 = a1.id
+            JOIN {s}.artist a2 ON laa.entity1 = a2.id
+            WHERE a1.gid = %s
+            UNION
+            SELECT a1.gid::text
+            FROM {s}.l_artist_artist laa
+            JOIN {s}.artist a1 ON laa.entity0 = a1.id
+            JOIN {s}.artist a2 ON laa.entity1 = a2.id
+            WHERE a2.gid = %s
+        """,
+    }
+
+
+# =============================================================================
+# Client
+# =============================================================================
+
+_BATCH_CHUNK_SIZE = 100  # max MBIDs per batch query
+
+
+class MusicBrainzDB:
+    """Postgres-backed MusicBrainz client.
+
+    Drop-in replacement for MusicBrainzClient — same methods, same return
+    types, but queries the local mirror directly via a connection pool.
+    No rate limiting needed.
+    """
+
+    def __init__(self, config: MusicBrainzDBConfig | None = None):
+        self.config = config or MusicBrainzDBConfig()
+        self._sql = _q(self.config.schema)
+        self._pool = ConnectionPool(
+            conninfo=self.config.conninfo,
+            min_size=self.config.pool_min,
+            max_size=self.config.pool_max,
+            open=True,
+        )
+
+        # Same caches as MusicBrainzClient
+        self._artist_rels_cache: dict[str, set[str]] = {}
+        self._recording_cache: dict[str, RecordingMetadata] = {}
+
+    # -------------------------------------------------------------------------
+    # Recording metadata
+    # -------------------------------------------------------------------------
+
+    def get_recording_metadata(self, mbid: str) -> RecordingMetadata:
+        """Fetch recording metadata from local Postgres mirror."""
+        if mbid in self._recording_cache:
+            return self._recording_cache[mbid]
+
+        try:
+            with self._pool.connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(self._sql["recording_single"], (mbid,))
+                    row = cur.fetchone()
+        except Exception:
+            logger.warning("MusicBrainzDB recording lookup failed for %s", mbid)
+            return RecordingMetadata()
+
+        if row is None:
+            meta = RecordingMetadata()
+        else:
+            artist_mbid, release_year, genres = row
+            meta = RecordingMetadata(
+                artist_mbid=artist_mbid,
+                release_year=release_year,
+                genre_tags=genres or [],
+            )
+
+        self._recording_cache[mbid] = meta
+        return meta
+
+    def get_recording_metadata_batch(
+        self,
+        mbids: list[str],
+    ) -> dict[str, RecordingMetadata]:
+        """Fetch recording metadata for multiple MBIDs in one query.
+
+        Replaces the Lucene-based batch search from MusicBrainzClient.
+        Chunks large lists to avoid oversized queries.
+        """
+        results: dict[str, RecordingMetadata] = {}
+        if not mbids:
+            return results
+
+        # Check cache first
+        uncached: list[str] = []
+        for mbid in mbids:
+            if mbid in self._recording_cache:
+                results[mbid] = self._recording_cache[mbid]
+            else:
+                uncached.append(mbid)
+
+        if not uncached:
+            return results
+
+        # Query in chunks
+        for i in range(0, len(uncached), _BATCH_CHUNK_SIZE):
+            chunk = uncached[i : i + _BATCH_CHUNK_SIZE]
+            try:
+                with self._pool.connection() as conn:
+                    with conn.cursor() as cur:
+                        cur.execute(self._sql["recording_batch"], (chunk,))
+                        for row in cur.fetchall():
+                            rec_mbid, artist_mbid, release_year, genres = row
+                            meta = RecordingMetadata(
+                                artist_mbid=artist_mbid,
+                                release_year=release_year,
+                                genre_tags=genres or [],
+                            )
+                            self._recording_cache[rec_mbid] = meta
+                            results[rec_mbid] = meta
+            except Exception:
+                logger.warning(
+                    "MusicBrainzDB batch lookup failed for %d MBIDs",
+                    len(chunk),
+                )
+
+        # Cache empty metadata for MBIDs not found
+        for mbid in uncached:
+            if mbid not in results:
+                meta = RecordingMetadata()
+                self._recording_cache[mbid] = meta
+                results[mbid] = meta
+
+        return results
+
+    # -------------------------------------------------------------------------
+    # Artist relationships
+    # -------------------------------------------------------------------------
+
+    def get_artist_relationships(self, artist_mbid: str) -> set[str]:
+        """Fetch related artist MBIDs from local Postgres mirror.
+
+        Queries both directions of l_artist_artist (entity0→entity1 and
+        entity1→entity0) to get the full relationship graph.
+        """
+        if artist_mbid in self._artist_rels_cache:
+            return self._artist_rels_cache[artist_mbid]
+
+        try:
+            with self._pool.connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        self._sql["artist_rels"],
+                        (artist_mbid, artist_mbid),
+                    )
+                    related = {row[0] for row in cur.fetchall()}
+        except Exception:
+            logger.warning("MusicBrainzDB artist lookup failed for %s", artist_mbid)
+            return set()
+
+        self._artist_rels_cache[artist_mbid] = related
+        return related
+
+    # -------------------------------------------------------------------------
+    # Cache management
+    # -------------------------------------------------------------------------
+
+    def cache_stats(self) -> dict[str, int]:
+        """Get cache statistics."""
+        return {
+            "recordings_cached": len(self._recording_cache),
+            "artists_cached": len(self._artist_rels_cache),
+        }
+
+    def clear_cache(self) -> None:
+        """Clear all caches."""
+        self._recording_cache.clear()
+        self._artist_rels_cache.clear()
+
+    def close(self) -> None:
+        """Close the connection pool."""
+        self._pool.close()
+
+    def __enter__(self) -> MusicBrainzDB:
+        return self
+
+    def __exit__(self, *args) -> None:
+        self.close()

--- a/modules/module2/src/module2/search_space.py
+++ b/modules/module2/src/module2/search_space.py
@@ -13,6 +13,7 @@ from module1 import MusicKnowledgeBase, TrackFeatures, TransitionResult
 from .acousticbrainz_client import AcousticBrainzClient
 from .listenbrainz_client import ListenBrainzClient
 from .musicbrainz_client import MusicBrainzClient
+from .musicbrainz_db import MusicBrainzDB
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +51,7 @@ class SearchSpace(SearchSpaceProtocol):
         self.kb = knowledge_base
         self.lb_client = lb_client or ListenBrainzClient()
         self.ab_client = ab_client or AcousticBrainzClient()
-        self.mb_client = mb_client or MusicBrainzClient()
+        self.mb_client = mb_client or MusicBrainzDB()
         self.neighborhood_size = neighborhood_size
 
         # In-memory caches

--- a/modules/module2/test_benchmark.py
+++ b/modules/module2/test_benchmark.py
@@ -1,0 +1,145 @@
+"""Benchmark: Postgres (MusicBrainzDB) vs Public API (MusicBrainzClient)
+
+Run from project root:
+    uv run python modules/module2/test_benchmark.py
+"""
+
+import sys
+import time
+
+sys.path.insert(0, "modules/module2/src")
+sys.path.insert(0, "modules/module1/src")
+
+from module2.musicbrainz_db import MusicBrainzDB
+from module2.musicbrainz_client import MusicBrainzClient
+
+# Real MBIDs — proxy pool seeds + well-known tracks verified in both DB and public API
+TEST_MBIDS = [
+    "1eac49da-3399-4d34-bbf3-a98a91e2758b",  # Congregation - Foo Fighters
+    "80c24793-6a40-4edb-b1bb-5a4e3946901e",  # Little Monster - Royal Blood
+    "ffcb45c3-7f32-427d-b3d4-287664bbcdb9",  # What Kind of Man - Florence + the Machine
+    "564ccd5c-c4d3-4752-9abf-c33bb085d6a5",  # The Lost Art of Conversation - Pink Floyd
+]
+
+ARTIST_MBIDS = [
+    "67f66c07-6e61-4026-ade5-7e782fad3a5d",  # Foo Fighters
+    "aa62b28e-b6d4-4086-91d4-e5fac1ed56f3",  # Royal Blood
+    "5fee3020-513b-48c2-b1f7-4681b01db0c6",  # Florence + the Machine
+    "83d91898-7763-47d7-b03b-b92132375c47",  # Pink Floyd
+    "a74b1b7f-71a5-4011-9441-d0b5e4122711",  # Radiohead
+]
+
+
+def bench(name, fn):
+    t0 = time.perf_counter()
+    result = fn()
+    elapsed = time.perf_counter() - t0
+    print(f"  {name}: {elapsed:.3f}s")
+    return elapsed
+
+
+def run_postgres(mbids):
+    print("\n=== Postgres (MusicBrainzDB) ===")
+    db = MusicBrainzDB()
+    times = {}
+
+    times["4 single lookups"] = bench(
+        "4 single lookups",
+        lambda: [db.get_recording_metadata(m) for m in mbids],
+    )
+    db.clear_cache()
+
+    times["4-MBID batch"] = bench(
+        "4-MBID batch",
+        lambda: db.get_recording_metadata_batch(mbids),
+    )
+    db.clear_cache()
+
+    times["5 artist rels"] = bench(
+        "5 artist rels",
+        lambda: [db.get_artist_relationships(a) for a in ARTIST_MBIDS],
+    )
+
+    db.close()
+    return times
+
+
+def run_api(mbids):
+    print("\n=== Public API (MusicBrainzClient) ===")
+    print("  (this will take ~10s+ due to 1 req/sec rate limit)")
+    api = MusicBrainzClient()
+    times = {}
+
+    times["4 single lookups"] = bench(
+        "4 single lookups",
+        lambda: [api.get_recording_metadata(m) for m in mbids],
+    )
+    api.clear_cache()
+
+    times["4-MBID batch"] = bench(
+        "4-MBID batch",
+        lambda: api.get_recording_metadata_batch(mbids),
+    )
+    api.clear_cache()
+
+    times["5 artist rels"] = bench(
+        "5 artist rels",
+        lambda: [api.get_artist_relationships(a) for a in ARTIST_MBIDS],
+    )
+
+    api.close()
+    return times
+
+
+if __name__ == "__main__":
+    mbids = TEST_MBIDS
+
+    # Run Postgres first (fast)
+    pg_times = run_postgres(mbids)
+
+    # Run API (slow — rate limited)
+    api_times = run_api(mbids)
+
+    # Results
+    print(f"\n{'Query':<25} {'API':>10} {'Postgres':>10} {'Speedup':>10}")
+    print("=" * 55)
+    for name in pg_times:
+        old = api_times[name]
+        new = pg_times[name]
+        speedup = old / new if new > 0 else float("inf")
+        print(f"{name:<25} {old:>9.3f}s {new:>9.3f}s {speedup:>9.0f}x")
+
+    total_api = sum(api_times.values())
+    total_pg = sum(pg_times.values())
+    print("-" * 55)
+    print(
+        f"{'TOTAL':<25} {total_api:>9.3f}s {total_pg:>9.3f}s {total_api / total_pg:>9.0f}x"
+    )
+
+    # Save results to markdown
+    from datetime import datetime
+    from pathlib import Path
+
+    out = Path(__file__).resolve().parent.parent.parent / "BENCHMARKS.md"
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M")
+    is_new = not out.exists()
+
+    with open(out, "a") as f:
+        if is_new:
+            f.write("# Benchmarks\n\n")
+            f.write("Postgres (local MusicBrainz mirror) vs Public API.\n\n")
+
+        f.write(f"## {timestamp}\n\n")
+        f.write("| Query | API | Postgres | Speedup |\n")
+        f.write("|-------|-----|----------|---------|\n")
+        for name in pg_times:
+            old = api_times[name]
+            new = pg_times[name]
+            speedup = old / new if new > 0 else float("inf")
+            f.write(f"| {name} | {old:.3f}s | {new:.3f}s | {speedup:.0f}x |\n")
+        f.write(
+            f"| **TOTAL** | **{total_api:.3f}s** | **{total_pg:.3f}s** | **{total_api / total_pg:.0f}x** |\n"
+        )
+        f.write("\n")
+
+    print(f"\nResults saved to {out}")

--- a/uv.lock
+++ b/uv.lock
@@ -261,12 +261,14 @@ version = "0.1.0"
 source = { editable = "modules/module2" }
 dependencies = [
     { name = "module1" },
+    { name = "psycopg", extra = ["binary", "pool"] },
     { name = "requests" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "module1", editable = "modules/module1" },
+    { name = "psycopg", extras = ["pool", "binary"], specifier = ">=3.1" },
     { name = "requests", specifier = ">=2.31.0" },
 ]
 
@@ -365,6 +367,67 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8f/9a/7233bdd320841af2df067eedd7871ebe489681060ab7fb75e6afa24102fa/problog-2.2.9.tar.gz", hash = "sha256:c347597a07c4a1a4aee4fc4e674b34d55d4952e94e58ee81f3477146739b90f0", size = 1563609, upload-time = "2025-09-23T09:13:32.508Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a1/77/6fd9d6a4e7ff252bc0acdebeba6de337598dbd46c541a294f24e9fb67d42/problog-2.2.9-py3-none-any.whl", hash = "sha256:c4c765e487ff4ff515d22d07a02b6a61cc5f15b95be521252c6b30564f8f1822", size = 1965874, upload-time = "2025-09-23T09:13:30.636Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/b6/379d0a960f8f435ec78720462fd94c4863e7a31237cf81bf76d0af5883bf/psycopg-3.3.3.tar.gz", hash = "sha256:5e9a47458b3c1583326513b2556a2a9473a1001a56c9efe9e587245b43148dd9", size = 165624, upload-time = "2026-02-18T16:52:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/5b/181e2e3becb7672b502f0ed7f16ed7352aca7c109cfb94cf3878a9186db9/psycopg-3.3.3-py3-none-any.whl", hash = "sha256:f96525a72bcfade6584ab17e89de415ff360748c766f0106959144dcbb38c698", size = 212768, upload-time = "2026-02-18T16:46:27.365Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+pool = [
+    { name = "psycopg-pool" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/0a/cac9fdf1df16a269ba0e5f0f06cac61f826c94cadb39df028cdfe19d3a33/psycopg_binary-3.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:05f32239aec25c5fb15f7948cffdc2dc0dac098e48b80a140e4ba32b572a2e7d", size = 4590414, upload-time = "2026-02-18T16:50:01.441Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/c0/d8f8508fbf440edbc0099b1abff33003cd80c9e66eb3a1e78834e3fb4fb9/psycopg_binary-3.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7c84f9d214f2d1de2fafebc17fa68ac3f6561a59e291553dfc45ad299f4898c1", size = 4669021, upload-time = "2026-02-18T16:50:08.803Z" },
+    { url = "https://files.pythonhosted.org/packages/04/05/097016b77e343b4568feddf12c72171fc513acef9a4214d21b9478569068/psycopg_binary-3.3.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e77957d2ba17cada11be09a5066d93026cdb61ada7c8893101d7fe1c6e1f3925", size = 5467453, upload-time = "2026-02-18T16:50:14.985Z" },
+    { url = "https://files.pythonhosted.org/packages/91/23/73244e5feb55b5ca109cede6e97f32ef45189f0fdac4c80d75c99862729d/psycopg_binary-3.3.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:42961609ac07c232a427da7c87a468d3c82fee6762c220f38e37cfdacb2b178d", size = 5151135, upload-time = "2026-02-18T16:50:24.82Z" },
+    { url = "https://files.pythonhosted.org/packages/11/49/5309473b9803b207682095201d8708bbc7842ddf3f192488a69204e36455/psycopg_binary-3.3.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae07a3114313dd91fce686cab2f4c44af094398519af0e0f854bc707e1aeedf1", size = 6737315, upload-time = "2026-02-18T16:50:35.106Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/5d/03abe74ef34d460b33c4d9662bf6ec1dd38888324323c1a1752133c10377/psycopg_binary-3.3.3-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d257c58d7b36a621dcce1d01476ad8b60f12d80eb1406aee4cf796f88b2ae482", size = 4979783, upload-time = "2026-02-18T16:50:42.067Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/6c/3fbf8e604e15f2f3752900434046c00c90bb8764305a1b81112bff30ba24/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:07c7211f9327d522c9c47560cae00a4ecf6687f4e02d779d035dd3177b41cb12", size = 4509023, upload-time = "2026-02-18T16:50:50.116Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6b/1a06b43b7c7af756c80b67eac8bfaa51d77e68635a8a8d246e4f0bb7604a/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:8e7e9eca9b363dbedeceeadd8be97149d2499081f3c52d141d7cd1f395a91f83", size = 4185874, upload-time = "2026-02-18T16:50:55.97Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d3/bf49e3dcaadba510170c8d111e5e69e5ae3f981c1554c5bb71c75ce354bb/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:cb85b1d5702877c16f28d7b92ba030c1f49ebcc9b87d03d8c10bf45a2f1c7508", size = 3925668, upload-time = "2026-02-18T16:51:03.299Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/92/0aac830ed6a944fe334404e1687a074e4215630725753f0e3e9a9a595b62/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4d4606c84d04b80f9138d72f1e28c6c02dc5ae0c7b8f3f8aaf89c681ce1cd1b1", size = 4234973, upload-time = "2026-02-18T16:51:09.097Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/96/102244653ee5a143ece5afe33f00f52fe64e389dfce8dbc87580c6d70d3d/psycopg_binary-3.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:74eae563166ebf74e8d950ff359be037b85723d99ca83f57d9b244a871d6c13b", size = 3551342, upload-time = "2026-02-18T16:51:13.892Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/71/7a57e5b12275fe7e7d84d54113f0226080423a869118419c9106c083a21c/psycopg_binary-3.3.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:497852c5eaf1f0c2d88ab74a64a8097c099deac0c71de1cbcf18659a8a04a4b2", size = 4607368, upload-time = "2026-02-18T16:51:19.295Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/04/cb834f120f2b2c10d4003515ef9ca9d688115b9431735e3936ae48549af8/psycopg_binary-3.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:258d1ea53464d29768bf25930f43291949f4c7becc706f6e220c515a63a24edd", size = 4687047, upload-time = "2026-02-18T16:51:23.84Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e9/47a69692d3da9704468041aa5ed3ad6fc7f6bb1a5ae788d261a26bbca6c7/psycopg_binary-3.3.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:111c59897a452196116db12e7f608da472fbff000693a21040e35fc978b23430", size = 5487096, upload-time = "2026-02-18T16:51:29.645Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b6/0e0dd6a2f802864a4ae3dbadf4ec620f05e3904c7842b326aafc43e5f464/psycopg_binary-3.3.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:17bb6600e2455993946385249a3c3d0af52cd70c1c1cdbf712e9d696d0b0bf1b", size = 5168720, upload-time = "2026-02-18T16:51:36.499Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/0d/977af38ac19a6b55d22dff508bd743fd7c1901e1b73657e7937c7cccb0a3/psycopg_binary-3.3.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:642050398583d61c9856210568eb09a8e4f2fe8224bf3be21b67a370e677eead", size = 6762076, upload-time = "2026-02-18T16:51:43.167Z" },
+    { url = "https://files.pythonhosted.org/packages/34/40/912a39d48322cf86895c0eaf2d5b95cb899402443faefd4b09abbba6b6e1/psycopg_binary-3.3.3-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:533efe6dc3a7cba5e2a84e38970786bb966306863e45f3db152007e9f48638a6", size = 4997623, upload-time = "2026-02-18T16:51:47.707Z" },
+    { url = "https://files.pythonhosted.org/packages/98/0c/c14d0e259c65dc7be854d926993f151077887391d5a081118907a9d89603/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:5958dbf28b77ce2033482f6cb9ef04d43f5d8f4b7636e6963d5626f000efb23e", size = 4532096, upload-time = "2026-02-18T16:51:51.421Z" },
+    { url = "https://files.pythonhosted.org/packages/39/21/8b7c50a194cfca6ea0fd4d1f276158307785775426e90700ab2eba5cd623/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a6af77b6626ce92b5817bf294b4d45ec1a6161dba80fc2d82cdffdd6814fd023", size = 4208884, upload-time = "2026-02-18T16:51:57.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2c/a4981bf42cf30ebba0424971d7ce70a222ae9b82594c42fc3f2105d7b525/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:47f06fcbe8542b4d96d7392c476a74ada521c5aebdb41c3c0155f6595fc14c8d", size = 3944542, upload-time = "2026-02-18T16:52:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e9/b7c29b56aa0b85a4e0c4d89db691c1ceef08f46a356369144430c155a2f5/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e7800e6c6b5dc4b0ca7cc7370f770f53ac83886b76afda0848065a674231e856", size = 4254339, upload-time = "2026-02-18T16:52:10.444Z" },
+    { url = "https://files.pythonhosted.org/packages/98/5a/291d89f44d3820fffb7a04ebc8f3ef5dda4f542f44a5daea0c55a84abf45/psycopg_binary-3.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:165f22ab5a9513a3d7425ffb7fcc7955ed8ccaeef6d37e369d6cc1dff1582383", size = 3652796, upload-time = "2026-02-18T16:52:14.02Z" },
+]
+
+[[package]]
+name = "psycopg-pool"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/9a/9470d013d0d50af0da9c4251614aeb3c1823635cab3edc211e3839db0bcf/psycopg_pool-3.3.0.tar.gz", hash = "sha256:fa115eb2860bd88fce1717d75611f41490dec6135efb619611142b24da3f6db5", size = 31606, upload-time = "2025-12-01T11:34:33.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c3/26b8a0908a9db249de3b4169692e1c7c19048a9bc41a4d3209cee7dbb758/psycopg_pool-3.3.0-py3-none-any.whl", hash = "sha256:2e44329155c410b5e8666372db44276a8b1ebd8c90f1c3026ebba40d4bc81063", size = 39995, upload-time = "2025-12-01T11:34:29.761Z" },
 ]
 
 [[package]]
@@ -528,6 +591,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/08/d5/655beb51224d1bfd4f9ddc0bb209659bfe71ff141bcf05c418ab670698f0/ty-0.0.14-py3-none-win32.whl", hash = "sha256:b20e22cf54c66b3e37e87377635da412d9a552c9bf4ad9fc449fed8b2e19dad2", size = 9507626, upload-time = "2026-01-27T00:57:41.43Z" },
     { url = "https://files.pythonhosted.org/packages/b6/d9/c569c9961760e20e0a4bc008eeb1415754564304fd53997a371b7cf3f864/ty-0.0.14-py3-none-win_amd64.whl", hash = "sha256:e312ff9475522d1a33186657fe74d1ec98e4a13e016d66f5758a452c90ff6409", size = 10437980, upload-time = "2026-01-27T00:57:36.422Z" },
     { url = "https://files.pythonhosted.org/packages/ad/0c/186829654f5bfd9a028f6648e9caeb11271960a61de97484627d24443f91/ty-0.0.14-py3-none-win_arm64.whl", hash = "sha256:b6facdbe9b740cb2c15293a1d178e22ffc600653646452632541d01c36d5e378", size = 9885831, upload-time = "2026-01-27T00:57:49.747Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2025.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Direct queries against local MusicBrainz mirror, replacing the rate-limited public API as the default data source. Connection-pooled via psycopg, schema-configurable, same interface as MusicBrainzClient.

- New: musicbrainz_db.py (MusicBrainzDB + MusicBrainzDBConfig)
- Edit: search_space.py default swapped to MusicBrainzDB
- Edit: __init__.py exports MusicBrainzDB
- New: test_benchmark.py for Postgres vs API comparison
- Dep: psycopg[pool,binary]>=3.1