### PR TITLE
FEAT: Module4 training with db

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,9 @@
       "Bash(uv run python -m pytest:*)",
       "WebFetch(domain:listenbrainz.readthedocs.io)",
       "WebFetch(domain:api.listenbrainz.org)",
-      "WebFetch(domain:musicbrainz.org)"
+      "WebFetch(domain:musicbrainz.org)",
+      "Bash(wc -l /mnt/hardisk/project-2-ai-system-rocking-rolling/modules/module*/src/module*/test_*.py /mnt/hardisk/project-2-ai-system-rocking-rolling/modules/module*/src/module*/tests/test_*.py)",
+      "WebFetch(domain:essentia.upf.edu)"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,5 @@ build/
 .idea/
 .vscode/
 *.egg-info/
-modules/*/models/
-!modules/*/models/.gitkeep
+.pgpass
+.envrc

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,22 @@
+# Benchmarks
+
+Postgres (local MusicBrainz mirror) vs Public API.
+
+## 2026-04-01 00:32
+
+| Query | API | Postgres | Speedup |
+|-------|-----|----------|---------|
+| 25 single lookups | 43.526s | 24.888s | 2x |
+| 25-MBID batch | 1.160s | 0.931s | 1x |
+| 5 artist rels | 6.313s | 2.331s | 3x |
+| **TOTAL** | **50.999s** | **28.150s** | **2x** |
+
+## 2026-04-01 00:43
+
+| Query | API | Postgres | Speedup |
+|-------|-----|----------|---------|
+| 4 single lookups | 7.757s | 5.073s | 2x |
+| 4-MBID batch | 1.749s | 0.972s | 2x |
+| 5 artist rels | 5.816s | 2.106s | 3x |
+| **TOTAL** | **15.322s** | **8.151s** | **2x** |
+

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 Wave Guide creates personalized music playlists that take listeners on a "journey" from a starting track to a destination track, discovering new music along the way. Unlike traditional recommendation systems that optimize for similarity alone, Wave Guide treats playlist generation as a path-finding problem through multidimensional audio feature space.
 
-The system addresses a critical limitation in existing music platforms: Spotify recently restricted API access to recommendation endpoints, making proprietary solutions unsustainable. Wave Guide leverages AcousticBrainz, an open-source database containing acoustic analysis for millions of tracks (71-dimensional feature vectors including energy, valence, timbre, rhythm, and tonal characteristics).
+The system addresses a critical limitation in existing music platforms: Spotify recently restricted API access to recommendation endpoints, making proprietary solutions unsustainable. Wave Guide leverages open-source music databases (MusicBrainz, AcousticBrainz, ListenBrainz) and a self-hosted MusicBrainz Postgres mirror for fast, rate-limit-free access to 38M+ recordings.
 
-Users specify source and destination tracks (or moods). The system encodes music theory knowledge and transition smoothness rules as a propositional logic knowledge base, then uses search algorithms to find optimal paths through feature space that satisfy these constraints. The final playlist balances smooth transitions, stylistic diversity, and adherence to music theory principles.
+Users specify source and destination tracks (or moods). The system encodes music theory knowledge and transition smoothness rules as a probabilistic logic knowledge base, uses bidirectional beam search to find optimal paths through the ListenBrainz similarity graph, applies CSP constraints and user preference learning, and generates human-readable explanations for every playlist decision.
 
 ## Team
 
@@ -16,16 +16,50 @@ Users specify source and destination tracks (or moods). The system encodes music
 
 ## Proposal
 
-See [PROPOSAL.md](./PROPOSAL.md) for the full system proposal including detailed module specifications and feasibility study.
+See [PROPOSAL.md](./PROPOSAL.md) for the full system proposal.
+
+## Architecture
+
+```
+User Input (source + dest tracks or moods)
+    |
+    v
+Module 4: Mood Classification (mood label -> feature centroid)
+    |
+    v
+Module 2: Path Finding (bidirectional beam search over LB graph)
+    |   Uses: MusicBrainzDB (Postgres) | AcousticBrainzClient | ListenBrainzClient
+    v
+Module 1: Scoring (12-dimension compatibility via ProbLog KB)
+    |
+    v
+Module 3: Assembly (constraints + user model + explanations)
+    |
+    v
+Flask API -> React Web UI
+```
+
+## Modules
+
+| Module | Topic | What it does | Tests |
+|--------|-------|-------------|-------|
+| 1 | Probabilistic Logic | 12-dimension compatibility scoring via ProbLog KB | 44 |
+| 2 | Search | Bidirectional beam search, MusicBrainzDB (Postgres), AB/LB clients | 41 |
+| 3 | Constraint Satisfaction | CSP constraints, user model, Essentia fallback, proxy pool, explanations | 94 |
+| 4 | Machine Learning | Mood classification (LR/MLP), genre-to-mood mapping, DB training pipeline | 3 test files |
+| API | Integration | Flask REST API for compare + playlist generation | - |
+| Web | Frontend | React/TypeScript UI with song search, comparison, playlist generation | - |
+
+**Total: 179+ tests, 7,500+ lines of source code across 4 modules.**
 
 ## Module Plan
 
 | Module | Topic(s) | Inputs | Outputs | Depends On | Checkpoint |
 | ------ | -------- | ------ | ------- | ---------- | ---------- |
-| 1 | Probabalistic Logic (KB, Inference, Rules) | AcousticBrainz feature JSON, user constraints | Knowledge base with compatibility scoring | None | 1 |
+| 1 | Probabilistic Logic (KB, Inference, Rules) | AcousticBrainz feature JSON, user constraints | Knowledge base with compatibility scoring | None | 1 |
 | 2 | Search (Beam Search) | Source/dest feature vectors, KB rules | Ordered waypoint sequence | Module 1 | 1 |
-| 3 | Simulated Annealing | Playlist with metadata | Optimized playlist ordering | Module 2 | 2 |
-| 4 | Machine Learning (Supervised) | Feature vectors or mood labels | Mood classification / feature mapping | None | 4 |
+| 3 | Constraint Satisfaction | Playlist with metadata, user feedback | Optimized playlist with explanations | Module 2 | 2 |
+| 4 | Machine Learning (Supervised) | Feature vectors or mood labels | Mood classification / feature mapping | Module 1 | 4 |
 | 5 | System Integration | User input, all module outputs | Complete validated playlist | Modules 1-4 | 5 |
 
 ## Repository Layout
@@ -33,25 +67,54 @@ See [PROPOSAL.md](./PROPOSAL.md) for the full system proposal including detailed
 ```
 wave-guide/
 ├── modules/
-│   ├── module1/                      # Music Feature Knowledge Base
+│   ├── module1/                        # Music Feature Knowledge Base
 │   │   ├── src/module1/
-│   │   │   ├── knowledge_base.py     # ProbLog-based KB with Python API
-│   │   │   ├── data_models.py        # TrackFeatures, TransitionResult, etc.
-│   │   │   ├── data_loader.py        # AcousticBrainz JSON parsing
-│   │   │   ├── rules_helpers.py      # Research-grounded compatibility functions
-│   │   │   ├── music_theory.pl       # ProbLog rules
-│   │   │   └── test_main.py          # Unit tests
-│   │   └── test_files/               # Sample AcousticBrainz data
-│   └── api/                          # Flask REST API wrapper
+│   │   │   ├── knowledge_base.py       # ProbLog-based KB with Python API
+│   │   │   ├── data_models.py          # TrackFeatures, TransitionResult, UserPreferences
+│   │   │   ├── data_loader.py          # AcousticBrainz JSON parsing
+│   │   │   └── rules_helpers.py        # Research-grounded compatibility functions
+│   │   └── CHANGELOG.md
+│   ├── module2/                        # Path Finding + Data Clients
+│   │   ├── src/module2/
+│   │   │   ├── beam_search.py          # Bidirectional beam search with A* priority
+│   │   │   ├── musicbrainz_db.py       # Postgres-backed MB client (no rate limits)
+│   │   │   ├── musicbrainz_client.py   # Public MB API client (1 req/sec fallback)
+│   │   │   ├── acousticbrainz_client.py # AB batch feature API
+│   │   │   ├── listenbrainz_client.py  # LB neighbor discovery (4 algorithms)
+│   │   │   └── search_space.py         # Orchestrates all data sources
+│   │   ├── test_benchmark.py           # Postgres vs API performance comparison
+│   │   └── CHANGELOG.md
+│   ├── module3/                        # Playlist Assembly
+│   │   ├── src/module3/
+│   │   │   ├── playlist_assembler.py   # Full pipeline orchestrator
+│   │   │   ├── constraints.py          # 6 CSP constraint types + min-conflicts
+│   │   │   ├── explainer.py            # 3-level explanation system
+│   │   │   ├── essentia_client.py      # Audio analysis fallback (yt-dlp + Essentia)
+│   │   │   ├── proxy_pool.py           # Auto-growing pool for zero-neighbor tracks
+│   │   │   └── user_model.py           # Online preference learning (EMA)
+│   │   ├── USAGE.md
+│   │   └── CHANGELOG.md
+│   ├── module4/                        # Mood Classification
+│   │   ├── src/module4/
+│   │   │   ├── mood_classifier.py      # LR / MLP / Ensemble classifiers
+│   │   │   ├── feature_engineering.py  # 23-dim normalized feature extraction
+│   │   │   ├── training_data.py        # DB pipeline, synthetic data, parquet cache
+│   │   │   └── data_models.py          # MoodLabel, TrainingExample, EvalMetrics
+│   │   ├── USAGE.md
+│   │   └── CHANGELOG.md
+│   └── api/                            # Flask REST API
 │       └── src/api/app.py
-├── web/                              # React TypeScript frontend
-│   └── src/App.tsx
-├── plans/                            # Module planning documentation
-├── .claude/skills/code-review/       # Rubric-based review skill
-├── PROPOSAL.md                       # Detailed system proposal
-├── AGENTS.md                         # LLM agent instructions
-├── UNIT_TEST_RESULTS.md              # Test execution summary
-└── README.md                         # This file
+├── web/                                # React TypeScript frontend
+│   └── src/
+│       ├── App.tsx
+│       ├── hooks/                      # useCompare, usePlaylistGenerator, useRecordingSearch
+│       ├── components/                 # SongPicker, PlaylistResults, TransitionBar, etc.
+│       └── api/                        # OpenAPI client
+├── plans/                              # Module planning documentation
+├── rubrics/                            # Checkpoint review rubrics
+├── PROPOSAL.md                         # Detailed system proposal
+├── AGENTS.md                           # LLM agent instructions
+└── pyproject.toml                      # Root workspace config
 ```
 
 ## Setup
@@ -60,65 +123,106 @@ wave-guide/
 
 - Python 3.13+
 - [uv](https://docs.astral.sh/uv/) package manager
+- [direnv](https://direnv.net/) (for auto-loading environment variables)
 - Node.js 18+ and pnpm (for web frontend)
+- PostgreSQL access to MusicBrainz mirror (optional, for fast lookups)
 
 ### Installation
 
 ```bash
-# Clone the repository
 git clone <repo-url>
 cd project-2-ai-system-rocking-rolling
 
-# Install Python dependencies
-uv sync
+# Install all Python dependencies (all 4 modules)
+uv lock && uv sync
 
-# Install web dependencies (optional, for frontend)
+# Install web dependencies (optional)
 cd web && pnpm install && cd ..
 ```
 
 ### Environment
 
-No environment variables required for core functionality. The system fetches data from the public AcousticBrainz API.
+Create a `.env` file at the project root (gitignored) with your MusicBrainz mirror credentials:
+
+```bash
+MB_DB_HOST=<your-db-host>
+MB_DB_USER=<your-db-user>
+MB_DB_NAME=musicbrainz
+MB_DB_SCHEMA=musicbrainz
+MB_DB_PORT=5432
+```
+
+Set up [direnv](https://direnv.net/) to auto-load env vars when you enter the project:
+
+```bash
+echo 'dotenv' > .envrc
+direnv allow
+```
+
+Configure `~/.pgpass` for passwordless Postgres auth (see [PostgreSQL docs](https://www.postgresql.org/docs/current/libpq-pgpass.html)):
+
+```
+<host>:<port>:<dbname>:<user>:<password>
+```
+
+Without Postgres access, the system falls back to the public MusicBrainz API (1 req/sec rate limit).
 
 ## Running
 
-### Interactive Demo
+### Playlist Generation (CLI)
 
 ```bash
-# Run the Module 1 interactive demo
-uv run python -m module1.main
+# Generate a playlist between two tracks
+uv run python -m module3.main <source_mbid> <dest_mbid>
+
+# JSON output
+uv run python -m module3.main <source_mbid> <dest_mbid> --json
 ```
+
+### Mood Classifier Training
+
+```bash
+# Train from Postgres + AcousticBrainz (recommended)
+uv run python -m module4.main --from-db --max-per-class 200 --model both
+
+# Train from synthetic data (no external deps)
+uv run python -m module4.main --synthetic --model both
+```
+
+See [modules/module4/USAGE.md](./modules/module4/USAGE.md) for full training options.
 
 ### Web Interface
 
 ```bash
-# Run both Flask API and React frontend
 just serve
 ```
 
 ### API Endpoints
 
 - `GET /api/health` - Health check
-- `GET /api/compare?recording_id_1=<MBID>&recording_id_2=<MBID>` - Compare two tracks by MusicBrainz ID
+- `GET /api/compare?recording_id_1=<MBID>&recording_id_2=<MBID>` - Compare two tracks
+- `GET /api/playlist?source_mbid=<MBID>&dest_mbid=<MBID>&length=7` - Generate playlist
+
+### Benchmarking (Postgres vs API)
+
+```bash
+uv run python modules/module2/test_benchmark.py
+```
+
+Results are saved to `BENCHMARKS.md`.
 
 ## Testing
 
-### Run All Tests
-
 ```bash
-just test
+# All modules
+uv run python -m pytest modules/ --tb=short -q
+
+# Individual modules
+uv run python -m pytest modules/module1/ -q
+uv run python -m pytest modules/module2/ -q
+uv run python -m pytest modules/module3/ -q
+uv run python -m pytest modules/module4/ -q
 ```
-
-### Test Coverage
-
-Module 1 includes 6 pytest tests covering:
-- Same track comparison (expects >70% compatibility)
-- Cross-genre comparison (Pop vs Classical)
-- Same-genre comparison (Classical vs Classical)
-- Low-level only data handling
-- Component score validation
-
-See [UNIT_TEST_RESULTS.md](./UNIT_TEST_RESULTS.md) for detailed test results and interpretation guide.
 
 ### Linting and Type Checking
 
@@ -128,20 +232,36 @@ just typecheck  # Type check with ty
 just fmt        # Format code
 ```
 
+## Database Infrastructure
+
+The project uses a self-hosted MusicBrainz Postgres mirror for fast metadata access:
+
+| Data | Records | Source |
+|------|---------|--------|
+| Recordings | 38M | MusicBrainz mirror (Postgres) |
+| Artists | 2.8M | MusicBrainz mirror |
+| Genre tags | 6.8M | MusicBrainz mirror |
+| Canonical search | 30M | Pre-joined table with GIN full-text index |
+| Audio features | ~2M | AcousticBrainz API (archived, batch access) |
+| Similarity graph | Live | ListenBrainz API (no rate limit) |
+
+See [dblearn/README.md](./dblearn/README.md) for full database documentation.
+
 ## Checkpoint Log
 
-| Checkpoint | Date | Modules Included | Status | Evidence |
-| ---------- | ---- | ---------------- | ------ | -------- |
-| 1 | Feb 11 | Module 1 | Complete | 6 tests passing, research-grounded algorithms |
-| 2 | Feb 26 | Module 3 | Pending | |
-| 3 | Mar 12 | | Pending | |
-| 4 | Apr 2 | Module 4 | Pending | |
+| Checkpoint | Date | Modules | Status | Evidence |
+|------------|------|---------|--------|----------|
+| 1 | Feb 11 | Module 1 | Complete | 44 tests, research-grounded algorithms, [rubric](./rubrics/checkpoint-1.md) |
+| 2 | Feb 26 | Module 2 + 3 | Complete | 135 tests, [rubric](./rubrics/checkpoint-2.md) |
+| 3 | Mar 12 | DB Integration | In Progress | Postgres-backed MB client, benchmark suite |
+| 4 | Apr 2 | Module 4 | In Progress | Mood classifier, DB training pipeline |
 
 ## References
 
 ### Data Sources
-- [AcousticBrainz](https://acousticbrainz.org/) - Open music feature database (71-dimensional vectors)
-- [MusicBrainz](https://musicbrainz.org/) - Music metadata database
+- [MusicBrainz](https://musicbrainz.org/) - Open music metadata (38M+ recordings)
+- [AcousticBrainz](https://acousticbrainz.org/) - Audio feature database (archived 2022, ~2M recordings)
+- [ListenBrainz](https://listenbrainz.org/) - User listening data and similarity graph
 
 ### Research
 - Krumhansl, C. L. (1990). *Cognitive Foundations of Musical Pitch*. Oxford University Press.
@@ -150,6 +270,7 @@ just fmt        # Format code
 
 ### Libraries
 - [ProbLog](https://dtai.cs.kuleuven.be/problog/) - Probabilistic logic programming
-- [NumPy](https://numpy.org/) - Numerical computing
+- [scikit-learn](https://scikit-learn.org/) - Machine learning (mood classification)
+- [psycopg](https://www.psycopg.org/) - PostgreSQL adapter (connection pooling)
 - [Flask](https://flask.palletsprojects.com/) - Web framework
 - [React](https://react.dev/) - Frontend framework

--- a/modules/api/src/api/app.py
+++ b/modules/api/src/api/app.py
@@ -1,5 +1,8 @@
 """Flask API for computing song similarity scores using Module 1."""
 
+import logging
+from pathlib import Path
+
 import requests
 from flask import Flask, jsonify, request
 from module1 import MusicKnowledgeBase
@@ -7,11 +10,32 @@ from module1.data_loader import load_track_from_data
 from module2 import SearchSpace
 from module3 import PlaylistAssembler
 
+logger = logging.getLogger(__name__)
+
 app = Flask(__name__)
 
 ACOUSTICBRAINZ_BASE = "https://acousticbrainz.org/api/v1"
 
 kb = MusicKnowledgeBase()
+
+# ── Module 4: load trained mood classifier (optional, graceful fallback) ──
+MOOD_MODEL_PATH = (
+    Path(__file__).resolve().parents[3] / "module4" / "models" / "mood_classifier.pkl"
+)
+mood_classifier = None
+try:
+    from module4.mood_classifier import MoodClassifier
+
+    if MOOD_MODEL_PATH.exists() and MOOD_MODEL_PATH.stat().st_size > 0:
+        mood_classifier = MoodClassifier.load(MOOD_MODEL_PATH)
+        logger.info("Loaded mood classifier from %s", MOOD_MODEL_PATH)
+    else:
+        logger.warning("No trained mood classifier at %s", MOOD_MODEL_PATH)
+except Exception as exc:
+    logger.warning("Mood classifier unavailable: %s", exc)
+
+
+VALID_MOODS = {"calm", "chill", "sad", "happy", "energized", "intense"}
 
 
 def fetch_acousticbrainz(mbid: str) -> tuple[dict, dict]:
@@ -99,11 +123,13 @@ def health():
 def playlist():
     """Generate a playlist path between two songs using Module 2 beam search.
 
-    Query params:
-        source_mbid: MBID of the source/starting track
-        dest_mbid: MBID of the destination/ending track
-        length: Desired playlist length (default: 7)
-        beam_width: Beam width for search (default: 10)
+    Query params (provide either an MBID OR a mood label per endpoint):
+        source_mbid:  MBID of the source/starting track
+        source_mood:  Mood label (calm | chill | sad | happy | energized | intense)
+        dest_mbid:    MBID of the destination/ending track
+        dest_mood:    Mood label
+        length:       Desired playlist length (default: 7)
+        beam_width:   Beam width for search (default: 10)
 
     Returns:
         JSON with playlist metadata including track MBIDs, transitions,
@@ -111,53 +137,74 @@ def playlist():
     """
     source_mbid = request.args.get("source_mbid")
     dest_mbid = request.args.get("dest_mbid")
+    source_mood = request.args.get("source_mood")
+    dest_mood = request.args.get("dest_mood")
     length_str = request.args.get("length", "7")
     beam_width_str = request.args.get("beam_width", "10")
     length = int(length_str)
     beam_width = int(beam_width_str)
 
-    if not source_mbid or not dest_mbid:
-        return jsonify({"error": "Both source_mbid and dest_mbid are required."}), 400
+    # Validate that exactly one source spec and one dest spec was given
+    if not source_mbid and not source_mood:
+        return jsonify({"error": "Either source_mbid or source_mood is required."}), 400
+    if not dest_mbid and not dest_mood:
+        return jsonify({"error": "Either dest_mbid or dest_mood is required."}), 400
 
-    try:
-        # Fetch features for source and destination
-        source_low, source_high = fetch_acousticbrainz(source_mbid)
-        source_track = load_track_from_data(source_low, source_high)
-        source_track.mbid = source_mbid
-    except requests.HTTPError as e:
+    # Validate mood labels
+    for label, val in [("source_mood", source_mood), ("dest_mood", dest_mood)]:
+        if val and val not in VALID_MOODS:
+            return jsonify(
+                {"error": f"Invalid {label}: '{val}'. Must be one of {sorted(VALID_MOODS)}."}
+            ), 400
+
+    if (source_mood or dest_mood) and mood_classifier is None:
         return jsonify(
-            {"error": f"Failed to fetch AcousticBrainz data for source_mbid: {e}"}
-        ), 502
-    except requests.ConnectionError:
-        return jsonify({"error": "Could not connect to AcousticBrainz API."}), 502
+            {"error": "Mood-based seeds requested but no trained MoodClassifier is loaded."}
+        ), 503
+
+    # Build the search space; for MBID seeds, fetch AcousticBrainz first.
+    search_space = SearchSpace(knowledge_base=kb)
+
+    if source_mbid:
+        try:
+            source_low, source_high = fetch_acousticbrainz(source_mbid)
+            source_track = load_track_from_data(source_low, source_high)
+            source_track.mbid = source_mbid
+            search_space.add_features(source_mbid, source_track)
+        except requests.HTTPError as e:
+            return jsonify(
+                {"error": f"Failed to fetch AcousticBrainz data for source_mbid: {e}"}
+            ), 502
+        except requests.ConnectionError:
+            return jsonify({"error": "Could not connect to AcousticBrainz API."}), 502
+
+    if dest_mbid:
+        try:
+            dest_low, dest_high = fetch_acousticbrainz(dest_mbid)
+            dest_track = load_track_from_data(dest_low, dest_high)
+            dest_track.mbid = dest_mbid
+            search_space.add_features(dest_mbid, dest_track)
+        except requests.HTTPError as e:
+            return jsonify(
+                {"error": f"Failed to fetch AcousticBrainz data for dest_mbid: {e}"}
+            ), 502
+        except requests.ConnectionError:
+            return jsonify({"error": "Could not connect to AcousticBrainz API."}), 502
 
     try:
-        dest_low, dest_high = fetch_acousticbrainz(dest_mbid)
-        dest_track = load_track_from_data(dest_low, dest_high)
-        dest_track.mbid = dest_mbid
-    except requests.HTTPError as e:
-        return jsonify(
-            {"error": f"Failed to fetch AcousticBrainz data for dest_mbid: {e}"}
-        ), 502
-    except requests.ConnectionError:
-        return jsonify({"error": "Could not connect to AcousticBrainz API."}), 502
-
-    try:
-        # Initialize search space with source/dest features
-        search_space = SearchSpace(knowledge_base=kb)
-        search_space.add_features(source_mbid, source_track)
-        search_space.add_features(dest_mbid, dest_track)
-
         # Run full Module 3 pipeline (beam search + constraints + explanations)
         assembler = PlaylistAssembler(
             knowledge_base=kb,
             search_space=search_space,
             beam_width=beam_width,
+            mood_classifier=mood_classifier,
         )
 
         playlist = assembler.generate_playlist(
             source_mbid=source_mbid,
             dest_mbid=dest_mbid,
+            source_mood=source_mood,
+            dest_mood=dest_mood,
             target_length=length,
         )
 
@@ -215,6 +262,8 @@ def playlist():
             {
                 "source_mbid": source_mbid,
                 "dest_mbid": dest_mbid,
+                "source_mood": source_mood,
+                "dest_mood": dest_mood,
                 "requested_length": length,
                 "actual_length": path.length,
                 "total_cost": round(path.total_cost, 4),

--- a/modules/module1/src/module1/data_models.py
+++ b/modules/module1/src/module1/data_models.py
@@ -108,12 +108,14 @@ class TrackFeatures:
 
     @property
     def energy_score(self) -> float:
-        """Compute weighted energy score from frequency bands."""
-        return (
-            0.1 * self.energy_low
-            + 0.2 * self.energy_mid_low
-            + 0.4 * self.energy_mid_high
-            + 0.3 * self.energy_high
+        """Perceptual energy score in [0, 1] (log-normalized, weighted)."""
+        from .rules_helpers import compute_energy_score
+
+        return compute_energy_score(
+            self.energy_low,
+            self.energy_mid_low,
+            self.energy_mid_high,
+            self.energy_high,
         )
 
     @property

--- a/modules/module1/src/module1/rules_helpers.py
+++ b/modules/module1/src/module1/rules_helpers.py
@@ -277,29 +277,70 @@ def _bhattacharyya_distance(
     return float(term1 + term2)
 
 
+def _log_normalize(value: float, floor: float, ceiling: float) -> float:
+    """Normalize a raw energy value to [0, 1] using log scale.
+
+    Energy perception follows Weber's law (logarithmic), so we map
+    through log space before linear rescaling.  Values outside
+    [floor, ceiling] are clamped.
+    """
+    value = max(value, floor)
+    value = min(value, ceiling)
+    return (math.log(value) - math.log(floor)) / (
+        math.log(ceiling) - math.log(floor)
+    )
+
+
+# Empirical AcousticBrainz ranges per band (floor / ceiling).
+# Derived from sampling across genres; floor is ~silent, ceiling is
+# a loud track in that band.
+_BAND_RANGES: dict[str, tuple[float, float]] = {
+    "low": (1e-5, 0.05),        # 20-150 Hz
+    "mid_low": (1e-5, 0.08),    # 150-800 Hz
+    "mid_high": (1e-5, 0.10),   # 800-4 kHz
+    "high": (1e-7, 0.01),       # 4-20 kHz
+}
+
+# Perceptual weights: mid-high carries the most "energy feel",
+# high adds brightness/excitement, mid-low adds body.
+_BAND_WEIGHTS = {
+    "low": 0.10,
+    "mid_low": 0.20,
+    "mid_high": 0.40,
+    "high": 0.30,
+}
+
+
 def compute_energy_score(
     energy_low: float,
     energy_mid_low: float,
     energy_mid_high: float,
     energy_high: float,
 ) -> float:
-    """
-    Compute weighted energy score from spectral energy bands.
+    """Compute perceptual energy score from spectral energy bands.
+
+    Each band is independently log-normalized to [0, 1] using empirical
+    AcousticBrainz ranges, then combined with perceptual weights.
+    This produces a meaningful 0-1 score where ~0.3 is calm and ~0.7+
+    is energetic.
 
     Args:
-        energy_low: Low frequency band energy
-        energy_mid_low: Mid-low frequency band energy
-        energy_mid_high: Mid-high frequency band energy
-        energy_high: High frequency band energy
+        energy_low: Low frequency band energy (20-150 Hz)
+        energy_mid_low: Mid-low frequency band energy (150-800 Hz)
+        energy_mid_high: Mid-high frequency band energy (800-4 kHz)
+        energy_high: High frequency band energy (4-20 kHz)
 
     Returns:
-        Weighted energy score
+        Perceptual energy score in [0, 1]
     """
-    return (
-        0.1 * energy_low
-        + 0.2 * energy_mid_low
-        + 0.4 * energy_mid_high
-        + 0.3 * energy_high
+    raw = {"low": energy_low, "mid_low": energy_mid_low,
+           "mid_high": energy_mid_high, "high": energy_high}
+    normalized = {
+        band: _log_normalize(raw[band], *_BAND_RANGES[band])
+        for band in _BAND_WEIGHTS
+    }
+    return sum(
+        _BAND_WEIGHTS[b] * normalized[b] for b in _BAND_WEIGHTS
     )
 
 
@@ -425,12 +466,12 @@ def loudness_compatibility_prob(
 
 
 def energy_compatibility_prob(energy1: float, energy2: float) -> float:
-    """
-    Compute energy compatibility using Gaussian decay.
+    """Compute energy compatibility using Gaussian decay.
 
-    AcousticBrainz spectral energy scores are typically 0.001-0.01.
-    σ = 0.003 calibrated to actual data range.
+    After log-normalization, energy scores live on a [0, 1] perceptual
+    scale.  σ = 0.15 mirrors loudness compatibility (same scale) and
+    tolerates moderate energy jumps while penalising large ones.
     """
     delta = abs(energy1 - energy2)
-    sigma = 0.003
+    sigma = 0.15
     return math.exp(-(delta**2) / (2.0 * sigma**2))

--- a/modules/module2/pyproject.toml
+++ b/modules/module2/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Beam search path finding for playlist generation"
 readme = "README.md"
 requires-python = ">=3.13"
-dependencies = ["requests>=2.31.0", "module1"]
+dependencies = ["requests>=2.31.0", "module1", "psycopg[pool,binary]>=3.1"]
 
 [tool.uv.sources]
 module1 = { workspace = true }

--- a/modules/module2/src/module2/__init__.py
+++ b/modules/module2/src/module2/__init__.py
@@ -31,6 +31,7 @@ from .beam_search import BeamSearch
 from .data_models import PlaylistPath, SearchState, SimilarRecording
 from .listenbrainz_client import ListenBrainzClient, ListenBrainzConfig
 from .musicbrainz_client import MusicBrainzClient, MusicBrainzConfig
+from .musicbrainz_db import MusicBrainzDB, MusicBrainzDBConfig
 from .search_space import SearchSpace, SearchSpaceProtocol
 
 __all__ = [
@@ -49,4 +50,7 @@ __all__ = [
     "AcousticBrainzConfig",
     "MusicBrainzClient",
     "MusicBrainzConfig",
+    # Postgres-backed client
+    "MusicBrainzDB",
+    "MusicBrainzDBConfig",
 ]

--- a/modules/module2/src/module2/musicbrainz_db.py
+++ b/modules/module2/src/module2/musicbrainz_db.py
@@ -1,0 +1,297 @@
+"""MusicBrainz Postgres client — direct database queries, no rate limits.
+
+Drop-in replacement for MusicBrainzClient. Same interface, same return types,
+but queries a local MusicBrainz mirror via psycopg + connection pool instead
+of the REST API.
+
+Connection configurable via MusicBrainzDBConfig or MB_DB_* environment variables.
+Requires ~/.pgpass for passwordless auth.
+
+Usage:
+    # Uses env vars / defaults
+    db = MusicBrainzDB()
+    meta = db.get_recording_metadata("1eac49da-3399-4d34-bbf3-a98a91e2758b")
+
+    # Custom config
+    db = MusicBrainzDB(MusicBrainzDBConfig(host="10.0.0.5", schema="canonical"))
+
+    # Context manager (auto-closes pool)
+    with MusicBrainzDB() as db:
+        meta = db.get_recording_metadata(mbid)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+
+from psycopg_pool import ConnectionPool
+
+from .musicbrainz_client import RecordingMetadata
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+
+@dataclass
+class MusicBrainzDBConfig:
+    """Configuration for direct Postgres connection.
+
+    All fields can be overridden via environment variables (MB_DB_*) or
+    passed directly. Password is read from ~/.pgpass — never stored here.
+    """
+
+    host: str = ""
+    port: int = 0
+    dbname: str = ""
+    user: str = ""
+    schema: str = ""
+
+    # Connection pool sizing
+    pool_min: int = 1
+    pool_max: int = 5
+
+    def __post_init__(self):
+        self.host = self.host or os.environ.get("MB_DB_HOST", "localhost")
+        self.port = self.port or int(os.environ.get("MB_DB_PORT", "5432"))
+        self.dbname = self.dbname or os.environ.get("MB_DB_NAME", "musicbrainz")
+        self.user = self.user or os.environ.get("MB_DB_USER", "musicbrainz")
+        self.schema = self.schema or os.environ.get("MB_DB_SCHEMA", "musicbrainz")
+
+    @property
+    def conninfo(self) -> str:
+        """Build psycopg connection string (password via ~/.pgpass)."""
+        return (
+            f"host={self.host} port={self.port} dbname={self.dbname} user={self.user}"
+        )
+
+
+# =============================================================================
+# SQL Queries — parameterized, schema-prefixed
+# =============================================================================
+
+
+def _q(schema: str) -> dict[str, str]:
+    """Build all SQL queries with the configured schema prefix."""
+    s = schema
+
+    return {
+        "recording_single": f"""\
+            SELECT
+                a.gid::text    AS artist_mbid,
+                rfrd.year      AS release_year,
+                array_agg(DISTINCT g.name) FILTER (WHERE g.name IS NOT NULL) AS genres
+            FROM {s}.recording r
+            JOIN {s}.artist_credit_name acn ON r.artist_credit = acn.artist_credit
+            JOIN {s}.artist a ON acn.artist = a.id
+            LEFT JOIN {s}.recording_first_release_date rfrd ON r.id = rfrd.recording
+            LEFT JOIN {s}.recording_tag rt ON r.id = rt.recording
+            LEFT JOIN {s}.genre g ON rt.tag = g.id
+            WHERE r.gid = %s
+            GROUP BY a.gid, rfrd.year
+            LIMIT 1
+        """,
+        "recording_batch": f"""\
+            SELECT
+                r.gid::text    AS recording_mbid,
+                a.gid::text    AS artist_mbid,
+                rfrd.year      AS release_year,
+                array_agg(DISTINCT g.name) FILTER (WHERE g.name IS NOT NULL) AS genres
+            FROM {s}.recording r
+            JOIN {s}.artist_credit_name acn ON r.artist_credit = acn.artist_credit
+            JOIN {s}.artist a ON acn.artist = a.id
+            LEFT JOIN {s}.recording_first_release_date rfrd ON r.id = rfrd.recording
+            LEFT JOIN {s}.recording_tag rt ON r.id = rt.recording
+            LEFT JOIN {s}.genre g ON rt.tag = g.id
+            WHERE r.gid = ANY(%s)
+            GROUP BY r.gid, a.gid, rfrd.year
+        """,
+        "artist_rels": f"""\
+            SELECT a2.gid::text
+            FROM {s}.l_artist_artist laa
+            JOIN {s}.artist a1 ON laa.entity0 = a1.id
+            JOIN {s}.artist a2 ON laa.entity1 = a2.id
+            WHERE a1.gid = %s
+            UNION
+            SELECT a1.gid::text
+            FROM {s}.l_artist_artist laa
+            JOIN {s}.artist a1 ON laa.entity0 = a1.id
+            JOIN {s}.artist a2 ON laa.entity1 = a2.id
+            WHERE a2.gid = %s
+        """,
+    }
+
+
+# =============================================================================
+# Client
+# =============================================================================
+
+_BATCH_CHUNK_SIZE = 100  # max MBIDs per batch query
+
+
+class MusicBrainzDB:
+    """Postgres-backed MusicBrainz client.
+
+    Drop-in replacement for MusicBrainzClient — same methods, same return
+    types, but queries the local mirror directly via a connection pool.
+    No rate limiting needed.
+    """
+
+    def __init__(self, config: MusicBrainzDBConfig | None = None):
+        self.config = config or MusicBrainzDBConfig()
+        self._sql = _q(self.config.schema)
+        self._pool = ConnectionPool(
+            conninfo=self.config.conninfo,
+            min_size=self.config.pool_min,
+            max_size=self.config.pool_max,
+            open=True,
+        )
+
+        # Same caches as MusicBrainzClient
+        self._artist_rels_cache: dict[str, set[str]] = {}
+        self._recording_cache: dict[str, RecordingMetadata] = {}
+
+    # -------------------------------------------------------------------------
+    # Recording metadata
+    # -------------------------------------------------------------------------
+
+    def get_recording_metadata(self, mbid: str) -> RecordingMetadata:
+        """Fetch recording metadata from local Postgres mirror."""
+        if mbid in self._recording_cache:
+            return self._recording_cache[mbid]
+
+        try:
+            with self._pool.connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(self._sql["recording_single"], (mbid,))
+                    row = cur.fetchone()
+        except Exception:
+            logger.warning("MusicBrainzDB recording lookup failed for %s", mbid)
+            return RecordingMetadata()
+
+        if row is None:
+            meta = RecordingMetadata()
+        else:
+            artist_mbid, release_year, genres = row
+            meta = RecordingMetadata(
+                artist_mbid=artist_mbid,
+                release_year=release_year,
+                genre_tags=genres or [],
+            )
+
+        self._recording_cache[mbid] = meta
+        return meta
+
+    def get_recording_metadata_batch(
+        self,
+        mbids: list[str],
+    ) -> dict[str, RecordingMetadata]:
+        """Fetch recording metadata for multiple MBIDs in one query.
+
+        Replaces the Lucene-based batch search from MusicBrainzClient.
+        Chunks large lists to avoid oversized queries.
+        """
+        results: dict[str, RecordingMetadata] = {}
+        if not mbids:
+            return results
+
+        # Check cache first
+        uncached: list[str] = []
+        for mbid in mbids:
+            if mbid in self._recording_cache:
+                results[mbid] = self._recording_cache[mbid]
+            else:
+                uncached.append(mbid)
+
+        if not uncached:
+            return results
+
+        # Query in chunks
+        for i in range(0, len(uncached), _BATCH_CHUNK_SIZE):
+            chunk = uncached[i : i + _BATCH_CHUNK_SIZE]
+            try:
+                with self._pool.connection() as conn:
+                    with conn.cursor() as cur:
+                        cur.execute(self._sql["recording_batch"], (chunk,))
+                        for row in cur.fetchall():
+                            rec_mbid, artist_mbid, release_year, genres = row
+                            meta = RecordingMetadata(
+                                artist_mbid=artist_mbid,
+                                release_year=release_year,
+                                genre_tags=genres or [],
+                            )
+                            self._recording_cache[rec_mbid] = meta
+                            results[rec_mbid] = meta
+            except Exception:
+                logger.warning(
+                    "MusicBrainzDB batch lookup failed for %d MBIDs",
+                    len(chunk),
+                )
+
+        # Cache empty metadata for MBIDs not found
+        for mbid in uncached:
+            if mbid not in results:
+                meta = RecordingMetadata()
+                self._recording_cache[mbid] = meta
+                results[mbid] = meta
+
+        return results
+
+    # -------------------------------------------------------------------------
+    # Artist relationships
+    # -------------------------------------------------------------------------
+
+    def get_artist_relationships(self, artist_mbid: str) -> set[str]:
+        """Fetch related artist MBIDs from local Postgres mirror.
+
+        Queries both directions of l_artist_artist (entity0→entity1 and
+        entity1→entity0) to get the full relationship graph.
+        """
+        if artist_mbid in self._artist_rels_cache:
+            return self._artist_rels_cache[artist_mbid]
+
+        try:
+            with self._pool.connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        self._sql["artist_rels"],
+                        (artist_mbid, artist_mbid),
+                    )
+                    related = {row[0] for row in cur.fetchall()}
+        except Exception:
+            logger.warning("MusicBrainzDB artist lookup failed for %s", artist_mbid)
+            return set()
+
+        self._artist_rels_cache[artist_mbid] = related
+        return related
+
+    # -------------------------------------------------------------------------
+    # Cache management
+    # -------------------------------------------------------------------------
+
+    def cache_stats(self) -> dict[str, int]:
+        """Get cache statistics."""
+        return {
+            "recordings_cached": len(self._recording_cache),
+            "artists_cached": len(self._artist_rels_cache),
+        }
+
+    def clear_cache(self) -> None:
+        """Clear all caches."""
+        self._recording_cache.clear()
+        self._artist_rels_cache.clear()
+
+    def close(self) -> None:
+        """Close the connection pool."""
+        self._pool.close()
+
+    def __enter__(self) -> MusicBrainzDB:
+        return self
+
+    def __exit__(self, *args) -> None:
+        self.close()

--- a/modules/module2/src/module2/search_space.py
+++ b/modules/module2/src/module2/search_space.py
@@ -13,6 +13,7 @@ from module1 import MusicKnowledgeBase, TrackFeatures, TransitionResult
 from .acousticbrainz_client import AcousticBrainzClient
 from .listenbrainz_client import ListenBrainzClient
 from .musicbrainz_client import MusicBrainzClient
+from .musicbrainz_db import MusicBrainzDB
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +51,7 @@ class SearchSpace(SearchSpaceProtocol):
         self.kb = knowledge_base
         self.lb_client = lb_client or ListenBrainzClient()
         self.ab_client = ab_client or AcousticBrainzClient()
-        self.mb_client = mb_client or MusicBrainzClient()
+        self.mb_client = mb_client or MusicBrainzDB()
         self.neighborhood_size = neighborhood_size
 
         # In-memory caches

--- a/modules/module2/test_benchmark.py
+++ b/modules/module2/test_benchmark.py
@@ -1,0 +1,145 @@
+"""Benchmark: Postgres (MusicBrainzDB) vs Public API (MusicBrainzClient)
+
+Run from project root:
+    uv run python modules/module2/test_benchmark.py
+"""
+
+import sys
+import time
+
+sys.path.insert(0, "modules/module2/src")
+sys.path.insert(0, "modules/module1/src")
+
+from module2.musicbrainz_db import MusicBrainzDB
+from module2.musicbrainz_client import MusicBrainzClient
+
+# Real MBIDs — proxy pool seeds + well-known tracks verified in both DB and public API
+TEST_MBIDS = [
+    "1eac49da-3399-4d34-bbf3-a98a91e2758b",  # Congregation - Foo Fighters
+    "80c24793-6a40-4edb-b1bb-5a4e3946901e",  # Little Monster - Royal Blood
+    "ffcb45c3-7f32-427d-b3d4-287664bbcdb9",  # What Kind of Man - Florence + the Machine
+    "564ccd5c-c4d3-4752-9abf-c33bb085d6a5",  # The Lost Art of Conversation - Pink Floyd
+]
+
+ARTIST_MBIDS = [
+    "67f66c07-6e61-4026-ade5-7e782fad3a5d",  # Foo Fighters
+    "aa62b28e-b6d4-4086-91d4-e5fac1ed56f3",  # Royal Blood
+    "5fee3020-513b-48c2-b1f7-4681b01db0c6",  # Florence + the Machine
+    "83d91898-7763-47d7-b03b-b92132375c47",  # Pink Floyd
+    "a74b1b7f-71a5-4011-9441-d0b5e4122711",  # Radiohead
+]
+
+
+def bench(name, fn):
+    t0 = time.perf_counter()
+    result = fn()
+    elapsed = time.perf_counter() - t0
+    print(f"  {name}: {elapsed:.3f}s")
+    return elapsed
+
+
+def run_postgres(mbids):
+    print("\n=== Postgres (MusicBrainzDB) ===")
+    db = MusicBrainzDB()
+    times = {}
+
+    times["4 single lookups"] = bench(
+        "4 single lookups",
+        lambda: [db.get_recording_metadata(m) for m in mbids],
+    )
+    db.clear_cache()
+
+    times["4-MBID batch"] = bench(
+        "4-MBID batch",
+        lambda: db.get_recording_metadata_batch(mbids),
+    )
+    db.clear_cache()
+
+    times["5 artist rels"] = bench(
+        "5 artist rels",
+        lambda: [db.get_artist_relationships(a) for a in ARTIST_MBIDS],
+    )
+
+    db.close()
+    return times
+
+
+def run_api(mbids):
+    print("\n=== Public API (MusicBrainzClient) ===")
+    print("  (this will take ~10s+ due to 1 req/sec rate limit)")
+    api = MusicBrainzClient()
+    times = {}
+
+    times["4 single lookups"] = bench(
+        "4 single lookups",
+        lambda: [api.get_recording_metadata(m) for m in mbids],
+    )
+    api.clear_cache()
+
+    times["4-MBID batch"] = bench(
+        "4-MBID batch",
+        lambda: api.get_recording_metadata_batch(mbids),
+    )
+    api.clear_cache()
+
+    times["5 artist rels"] = bench(
+        "5 artist rels",
+        lambda: [api.get_artist_relationships(a) for a in ARTIST_MBIDS],
+    )
+
+    api.close()
+    return times
+
+
+if __name__ == "__main__":
+    mbids = TEST_MBIDS
+
+    # Run Postgres first (fast)
+    pg_times = run_postgres(mbids)
+
+    # Run API (slow — rate limited)
+    api_times = run_api(mbids)
+
+    # Results
+    print(f"\n{'Query':<25} {'API':>10} {'Postgres':>10} {'Speedup':>10}")
+    print("=" * 55)
+    for name in pg_times:
+        old = api_times[name]
+        new = pg_times[name]
+        speedup = old / new if new > 0 else float("inf")
+        print(f"{name:<25} {old:>9.3f}s {new:>9.3f}s {speedup:>9.0f}x")
+
+    total_api = sum(api_times.values())
+    total_pg = sum(pg_times.values())
+    print("-" * 55)
+    print(
+        f"{'TOTAL':<25} {total_api:>9.3f}s {total_pg:>9.3f}s {total_api / total_pg:>9.0f}x"
+    )
+
+    # Save results to markdown
+    from datetime import datetime
+    from pathlib import Path
+
+    out = Path(__file__).resolve().parent.parent.parent / "BENCHMARKS.md"
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M")
+    is_new = not out.exists()
+
+    with open(out, "a") as f:
+        if is_new:
+            f.write("# Benchmarks\n\n")
+            f.write("Postgres (local MusicBrainz mirror) vs Public API.\n\n")
+
+        f.write(f"## {timestamp}\n\n")
+        f.write("| Query | API | Postgres | Speedup |\n")
+        f.write("|-------|-----|----------|---------|\n")
+        for name in pg_times:
+            old = api_times[name]
+            new = pg_times[name]
+            speedup = old / new if new > 0 else float("inf")
+            f.write(f"| {name} | {old:.3f}s | {new:.3f}s | {speedup:.0f}x |\n")
+        f.write(
+            f"| **TOTAL** | **{total_api:.3f}s** | **{total_pg:.3f}s** | **{total_api / total_pg:.0f}x** |\n"
+        )
+        f.write("\n")
+
+    print(f"\nResults saved to {out}")

--- a/modules/module3/src/module3/playlist_assembler.py
+++ b/modules/module3/src/module3/playlist_assembler.py
@@ -2,11 +2,12 @@
 
 Pipeline:
 1. Apply user preferences (if UserProfile exists)
-2. Run beam search (Module 2's find_path_bidirectional)
-3. Resolve features for all tracks in the path
-4. Apply constraints (CSP local search)
-5. Generate explanations
-6. Return AssembledPlaylist
+2. Resolve mood-based seeds via Module 4 (if mood label given instead of MBID)
+3. Run beam search (Module 2's find_path_bidirectional)
+4. Resolve features for all tracks in the path
+5. Apply constraints (CSP local search)
+6. Generate explanations
+7. Return AssembledPlaylist
 """
 
 from __future__ import annotations
@@ -14,9 +15,13 @@ from __future__ import annotations
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from module1 import MusicKnowledgeBase, TrackFeatures, TransitionResult, UserPreferences
 from module2 import BeamSearch, PlaylistPath, SearchSpace, SearchSpaceProtocol
+
+if TYPE_CHECKING:
+    from module4.mood_classifier import MoodClassifier
 
 from .constraints import (
     DEFAULT_CONSTRAINTS,
@@ -47,6 +52,7 @@ class PlaylistAssembler:
         constraints: list[PlaylistConstraint] | None = None,
         beam_width: int = 10,
         profile_path: Path | None = None,
+        mood_classifier: "MoodClassifier | None" = None,
     ):
         self.kb = knowledge_base or MusicKnowledgeBase()
         self.search_space = search_space
@@ -55,21 +61,59 @@ class PlaylistAssembler:
         self.constraints = constraints or list(DEFAULT_CONSTRAINTS)
         self.beam_width = beam_width
         self._profile_path = profile_path
+        self.mood_classifier = mood_classifier
+
+    def _resolve_mood_seed(
+        self,
+        search_space: SearchSpaceProtocol,
+        mood: str,
+    ) -> str:
+        """Convert a mood label into a synthetic seed MBID for beam search.
+
+        Uses Module 4's centroid track for that mood and injects it into the
+        search space so beam search can treat it like any other source/dest.
+
+        Returns the synthetic MBID (e.g. "mood:happy").
+        """
+        if self.mood_classifier is None:
+            raise RuntimeError(
+                "mood_classifier is required to use mood-based seeds. "
+                "Pass a trained MoodClassifier to PlaylistAssembler()."
+            )
+        # Lazy import keeps Module 3 independent of Module 4 at import-time.
+        from module4.data_models import MoodLabel
+
+        mood_label = MoodLabel(mood)
+        centroid_track = self.mood_classifier.get_centroid_track(mood_label)
+        synthetic_mbid = f"mood:{mood}"
+        centroid_track.mbid = synthetic_mbid
+        # Inject into search space so beam search can read its features.
+        if hasattr(search_space, "add_features"):
+            search_space.add_features(synthetic_mbid, centroid_track)
+        return synthetic_mbid
 
     def generate_playlist(
         self,
-        source_mbid: str,
-        dest_mbid: str,
+        source_mbid: str | None = None,
+        dest_mbid: str | None = None,
         target_length: int = 7,
         preferences: UserPreferences | None = None,
+        source_mood: str | None = None,
+        dest_mood: str | None = None,
     ) -> AssembledPlaylist | None:
         """Generate a complete playlist from source to destination.
+
+        Either an MBID or a mood label may be supplied for source/dest.
+        Mood labels are resolved through Module 4's MoodClassifier into
+        synthetic centroid tracks that seed the beam search.
 
         Args:
             source_mbid: MusicBrainz ID of the starting track
             dest_mbid: MusicBrainz ID of the ending track
-            target_length: Desired playlist length (number of tracks)
+            target_length: Desired playlist length
             preferences: Override preferences (otherwise uses user profile)
+            source_mood: Mood label seed (e.g. "happy") — alternative to source_mbid
+            dest_mood: Mood label seed — alternative to dest_mbid
 
         Returns:
             AssembledPlaylist with tracks, explanations, and constraint results,
@@ -89,7 +133,18 @@ class PlaylistAssembler:
         if search_space is None:
             search_space = SearchSpace(self.kb)
 
-        # Step 3: Run beam search
+        # Step 3: Resolve mood seeds via Module 4 (if provided)
+        if source_mood is not None:
+            source_mbid = self._resolve_mood_seed(search_space, source_mood)
+        if dest_mood is not None:
+            dest_mbid = self._resolve_mood_seed(search_space, dest_mood)
+
+        if not source_mbid or not dest_mbid:
+            raise ValueError(
+                "Provide either an MBID or a mood label for both source and destination."
+            )
+
+        # Step 4: Run beam search
         beam = BeamSearch(
             knowledge_base=self.kb,
             search_space=search_space,

--- a/modules/module3/src/module3/tests/test_constraints.py
+++ b/modules/module3/src/module3/tests/test_constraints.py
@@ -21,17 +21,27 @@ def _make_track(
     artist_mbid: str | None = None,
     bpm: float = 120.0,
     genre: str | None = "roc",
-    energy: float = 0.005,
+    energy: float = 0.5,
     mood_happy: tuple[str, float] | None = ("happy", 0.8),
     mood_sad: tuple[str, float] | None = None,
 ) -> TrackFeatures:
+    # Energy is a perceptual 0-1 value.  Because energy_score uses
+    # log-normalization, we scale raw band values exponentially so that
+    # the 0-1 input maps linearly through log space.
+    import math
+    base_low, base_ml, base_mh, base_hi = 0.003, 0.005, 0.005, 0.0001
+    # Map energy 0→÷100, 0.5→1×, 1→×100  (exponential)
+    scale = math.pow(100, 2 * energy - 1)
     return TrackFeatures(
         mbid=mbid,
         artist=artist,
         artist_mbid=artist_mbid,
         bpm=bpm,
         genre_rosamerica=(genre, 0.9) if genre else None,
-        energy_mid_high=energy,
+        energy_low=base_low * scale,
+        energy_mid_low=base_ml * scale,
+        energy_mid_high=base_mh * scale,
+        energy_high=base_hi * scale,
         mood_happy=mood_happy,
         mood_sad=mood_sad,
     )
@@ -102,18 +112,18 @@ class TestNoRepeatedTracks(unittest.TestCase):
 class TestEnergyArcConstraint(unittest.TestCase):
     def test_rising_satisfied(self):
         tracks = [
-            _make_track(energy=0.001),
-            _make_track(energy=0.003),
-            _make_track(energy=0.006),
+            _make_track(energy=0.2),
+            _make_track(energy=0.5),
+            _make_track(energy=0.8),
         ]
         result = EnergyArcConstraint(target_arc="rising").evaluate(tracks)
         self.assertTrue(result.satisfied)
 
     def test_rising_violated(self):
         tracks = [
-            _make_track(energy=0.006),
-            _make_track(energy=0.003),
-            _make_track(energy=0.001),
+            _make_track(energy=0.8),
+            _make_track(energy=0.5),
+            _make_track(energy=0.2),
         ]
         result = EnergyArcConstraint(target_arc="rising").evaluate(tracks)
         self.assertFalse(result.satisfied)
@@ -121,24 +131,24 @@ class TestEnergyArcConstraint(unittest.TestCase):
 
     def test_falling_satisfied(self):
         tracks = [
-            _make_track(energy=0.008),
-            _make_track(energy=0.005),
-            _make_track(energy=0.002),
+            _make_track(energy=0.8),
+            _make_track(energy=0.5),
+            _make_track(energy=0.2),
         ]
         result = EnergyArcConstraint(target_arc="falling").evaluate(tracks)
         self.assertTrue(result.satisfied)
 
     def test_flat_satisfied(self):
         tracks = [
-            _make_track(energy=0.005),
-            _make_track(energy=0.005),
-            _make_track(energy=0.005),
+            _make_track(energy=0.5),
+            _make_track(energy=0.5),
+            _make_track(energy=0.5),
         ]
         result = EnergyArcConstraint(target_arc="flat").evaluate(tracks)
         self.assertTrue(result.satisfied)
 
     def test_short_playlist_always_satisfied(self):
-        tracks = [_make_track(energy=0.001), _make_track(energy=0.009)]
+        tracks = [_make_track(energy=0.2), _make_track(energy=0.9)]
         result = EnergyArcConstraint(target_arc="rising").evaluate(tracks)
         self.assertTrue(result.satisfied)
 

--- a/modules/module4/CHANGELOG.md
+++ b/modules/module4/CHANGELOG.md
@@ -1,0 +1,109 @@
+# Module 4 Changelog
+
+## 2026-04-01 — DB Training Pipeline + Bug Fixes
+
+### Fixed: Cross-validation per-class metrics were all zeros
+- `_train_cv()` returned empty per-class precision/recall/f1 after CV
+- Now evaluates on the refitted model to produce real per-class breakdown
+- CV accuracy/F1-macro (reliable) are kept; per-class comes from full refit
+
+### New: `load_from_db()` — real training data from Postgres + AcousticBrainz
+- Queries the local MusicBrainz mirror for recordings with genre tags
+- Maps 58 genres → 6 mood labels via `GENRE_TO_MOOD` dict
+- Fetches AcousticBrainz audio features in batches of 25
+- Extracts 23-dim feature vectors using `extract_features()`
+- tqdm progress bars for genre query + feature extraction steps
+- CLI: `uv run python -m module4.main --from-db --max-per-class 200`
+
+### New: Parquet cache for training data
+- `save_to_parquet()` / `load_from_parquet()` for fast reloading
+- Saved to `modules/module4/data/training_examples.parquet`
+- First `--from-db` run builds the cache; subsequent runs can reuse it
+
+### Fixed: Hardcoded `DATA_DIR` path
+- Was `~/Projects/metabrains-api/data` (Michael's local filesystem)
+- Now reads from `AB_DATA_DIR` environment variable, no default path
+
+### New: `--from-db`, `--synthetic`, `--data-dir` CLI flags
+- Three mutually exclusive data sources
+- Default: tries DB first, falls back to synthetic
+- `--synthetic` works standalone with no external dependencies
+
+### Added: module2 as dependency
+- `load_from_db()` imports `MusicBrainzDB` and `AcousticBrainzClient`
+- `pyproject.toml` now lists `module2` as workspace dependency
+
+---
+
+## Training Data Representativeness — Known Limitations
+
+### What the current pipeline does NOT capture well
+
+**Genre ≠ Mood.** The pipeline uses MusicBrainz genre tags as a proxy for mood labels. This introduces systematic label noise:
+- A "blues" track is labeled "sad", but many blues tracks are upbeat
+- "Pop" → "happy", but pop includes sad ballads, intense anthems, chill tracks
+- "Jazz" → "chill", but free jazz and bebop are anything but chill
+
+**Genre imbalance.** The MusicBrainz database has uneven genre coverage:
+- "Rock" and "pop" have millions of tagged recordings
+- "Slowcore", "funeral doom metal", "bossa nova" have hundreds
+- Result: some mood classes draw from 1-2 dominant genres
+
+**AB coverage gaps.** Not all MB recordings have AcousticBrainz features:
+- AB archived in 2022 with ~2M recordings analyzed
+- MB has 38M recordings — most won't have AB data
+- The pipeline silently skips tracks without AB features, biasing toward well-covered genres
+
+**No randomization in DB query.** The Postgres query returns deterministic results:
+- `LIMIT N` without `ORDER BY RANDOM()` gives the same recordings every time
+- Training set doesn't represent the full diversity within each genre
+
+### What IS representative
+
+- The **23-dim feature vector** is well-designed — uses real audio descriptors (BPM, energy bands, MFCC, loudness, etc.)
+- The **model architecture** (LR + MLP) is appropriate for this feature space
+- The **centroid-based inverse mapping** correctly reconstructs TrackFeatures from mood labels
+- The **AB features themselves** are high-quality when available (extracted by Essentia)
+
+### How to improve representativeness
+
+1. **Use AB highlevel mood classifiers** instead of genre tags — AB has `mood_happy`, `mood_sad`, `mood_aggressive`, `mood_relaxed`, `mood_party` probabilities. These are direct mood signals, not genre proxies. The `derive_mood_label()` function already supports this path.
+
+2. **Add `ORDER BY RANDOM()` to the DB query** — ensures genre diversity within each mood class.
+
+3. **Increase `max_per_class` to 500-1000** — more data smooths out per-genre bias.
+
+4. **Multi-label genre sampling** — instead of mapping one genre per recording, sample recordings that appear under multiple mood-relevant genres (e.g., a track tagged both "blues" and "rock" gives a more nuanced signal).
+
+5. **Load the AB data dump into Postgres** — once available, eliminates the API bottleneck and gives access to the full ~2M recordings with features.
+
+---
+
+## 2026-03-31 (v1) — Core Implementation
+
+### New: Mood Classifier (`mood_classifier.py`)
+- Three model types: Logistic Regression, MLP (256→128), Ensemble (LR+MLP soft voting)
+- 5-fold stratified cross-validation
+- GridSearchCV hyperparameter tuning (`--tune`)
+- Model persistence via pickle (save/load)
+- `classify_track(TrackFeatures)` → `MoodClassification` (mood + confidence + top-3)
+- `get_centroid_track(MoodLabel)` → `TrackFeatures` for mood-based playlist input
+
+### New: Feature Engineering (`feature_engineering.py`)
+- 23-dim normalized [0,1] feature vector from TrackFeatures
+- BPM, 4 energy bands, loudness, dynamic complexity, dissonance, spectral centroid, onset rate, 13 MFCCs
+- Music-aware normalization ranges (BPM 50-220, centroid 0-11025 Hz, etc.)
+- Inverse mapping: `features_to_track()` for centroid reconstruction
+
+### New: Training Data (`training_data.py`)
+- `generate_synthetic_data()` — Gaussian around per-mood centroids
+- `load_from_data_dir()` — loads from AB JSON files with rule-based mood derivation
+- `derive_mood_label()` — soft-scored mapping from AB mood probabilities
+
+### 6 Mood Labels
+- Calm, Chill, Sad, Happy, Energized, Intense
+
+### Tests
+- `test_feature_engineering.py` — extraction, normalization, inverse mapping
+- `test_mood_classifier.py` — train, classify, save/load, evaluate
+- `test_training_data.py` — synthetic generation, label derivation

--- a/modules/module4/USAGE.md
+++ b/modules/module4/USAGE.md
@@ -1,0 +1,133 @@
+# Module 4: Mood Classification — Usage Guide
+
+## Setup
+
+```bash
+uv lock --refresh && uv sync
+```
+
+## Training
+
+### From Postgres + AcousticBrainz (recommended)
+
+Uses real recordings from the MusicBrainz mirror, fetches audio features from AcousticBrainz, and maps genres to mood labels.
+
+Requires `~/.pgpass` configured for the MusicBrainz Postgres mirror.
+
+```bash
+# Train both models with 200 examples per mood class (1,200 total)
+uv run python -m module4.main --from-db --max-per-class 200 --model both
+
+# Train only logistic regression, smaller dataset
+uv run python -m module4.main --from-db --max-per-class 50 --model lr
+
+# Train with hyperparameter tuning (GridSearchCV)
+uv run python -m module4.main --from-db --max-per-class 200 --model both --tune
+```
+
+First run fetches from the API and saves a parquet cache at `modules/module4/data/training_examples.parquet`. Subsequent runs can load from parquet instantly.
+
+### From synthetic data (no external deps)
+
+Good for testing the pipeline without a database or API connection.
+
+```bash
+uv run python -m module4.main --synthetic --max-per-class 200 --model both
+```
+
+### From AcousticBrainz JSON files
+
+If you have local AB data dumps:
+
+```bash
+export AB_DATA_DIR=/path/to/data  # must have highlevel/ and lowlevel/ subdirs
+uv run python -m module4.main --data-dir $AB_DATA_DIR --max-per-class 500
+```
+
+### Default behavior
+
+If no flag is given, tries Postgres first, falls back to synthetic:
+
+```bash
+uv run python -m module4.main
+```
+
+## Output
+
+Training prints per-class metrics:
+
+```
+--- Logistic Regression (5-fold CV) ---
+Test accuracy: 0.892, F1-macro: 0.887
+              precision    recall       f1   support
+  calm            0.91      0.88     0.89        40
+  chill           0.85      0.82     0.84        40
+  energized       0.92      0.95     0.93        40
+  happy           0.87      0.85     0.86        40
+  intense         0.95      0.97     0.96        40
+  sad             0.83      0.85     0.84        40
+```
+
+Best model is saved to `modules/module4/models/mood_classifier.pkl`.
+
+## Using a trained model
+
+```python
+from module4 import MoodClassifier, MoodLabel
+
+# Load saved model
+clf = MoodClassifier.load("modules/module4/models/mood_classifier.pkl")
+
+# Classify a track (from Module 1's TrackFeatures)
+result = clf.classify_track(track_features)
+print(f"Mood: {result.mood.value}, confidence: {result.confidence:.2f}")
+print(f"Top 3: {[(m.value, f'{p:.2f}') for m, p in result.top_3_moods]}")
+
+# Get centroid track for mood-based playlist input
+# (use as source/dest for Module 2's beam search)
+calm_track = clf.get_centroid_track(MoodLabel.CALM)
+energized_track = clf.get_centroid_track(MoodLabel.ENERGIZED)
+```
+
+## Parquet cache
+
+After `--from-db` training, examples are cached at:
+
+```
+modules/module4/data/training_examples.parquet
+```
+
+Load directly in Python:
+
+```python
+from module4.training_data import load_from_parquet
+
+examples = load_from_parquet()
+print(f"Loaded {len(examples)} cached examples")
+```
+
+## Models
+
+| Model | Flag | Notes |
+|-------|------|-------|
+| Logistic Regression | `--model lr` | Fast, interpretable, prints feature importance |
+| MLP (256→128) | `--model mlp` | Better accuracy, slower to train |
+| Both | `--model both` | Trains both, saves the best |
+| Ensemble (LR+MLP) | `--model ensemble` | Soft voting, best accuracy |
+
+## Tests
+
+```bash
+uv run python -m pytest modules/module4/ --tb=short -q
+```
+
+## Mood labels
+
+| Mood | Example genres |
+|------|---------------|
+| Calm | classical, folk, new age, baroque |
+| Chill | ambient, jazz, trip hop, lo-fi |
+| Sad | blues, emo, gothic rock, dark ambient |
+| Happy | pop, reggae, soul, k-pop |
+| Energized | dance, techno, house, funk |
+| Intense | metal, industrial, hardcore punk |

--- a/modules/module4/pyproject.toml
+++ b/modules/module4/pyproject.toml
@@ -11,8 +11,11 @@ dependencies = [
     "numpy>=2.0.0",
     "scikit-learn>=1.6.0",
     "tqdm>=4.66.0",
+    "pyarrow>=15.0.0",
     "module1",
+    "module2",
 ]
 
 [tool.uv.sources]
 module1 = { workspace = true }
+module2 = { workspace = true }

--- a/modules/module4/src/module4/feature_engineering.py
+++ b/modules/module4/src/module4/feature_engineering.py
@@ -4,7 +4,10 @@ Extracts a 23-dimensional normalized [0, 1] feature vector from a TrackFeatures 
 using only lowlevel audio descriptors (not AB mood classifiers).
 """
 
+import math
+
 from module1.data_models import TrackFeatures
+from module1.rules_helpers import _log_normalize, _BAND_RANGES
 
 from .data_models import MoodLabel
 
@@ -63,23 +66,20 @@ def extract_features(track: TrackFeatures) -> list[float]:
     else:
         features.append(_clip01((float(bpm) - _BPM_MIN) / (_BPM_MAX - _BPM_MIN)))
 
-    # 1-4: Energy bands (AB stores as small floats, clip to [0, 1])
-    features.append(
-        _clip01(float(track.energy_low)) if track.energy_low is not None else 0.5
-    )
-    features.append(
-        _clip01(float(track.energy_mid_low))
-        if track.energy_mid_low is not None
-        else 0.5
-    )
-    features.append(
-        _clip01(float(track.energy_mid_high))
-        if track.energy_mid_high is not None
-        else 0.5
-    )
-    features.append(
-        _clip01(float(track.energy_high)) if track.energy_high is not None else 0.5
-    )
+    # 1-4: Energy bands — log-normalized to [0, 1] using empirical AB ranges
+    # (raw AB values are ~1e-5 to 0.1, so plain clip01 maps everything to ~0)
+    for band_name, attr_name in [
+        ("low", "energy_low"),
+        ("mid_low", "energy_mid_low"),
+        ("mid_high", "energy_mid_high"),
+        ("high", "energy_high"),
+    ]:
+        val = getattr(track, attr_name, None)
+        if val is None or val == 0.0:
+            features.append(0.5)
+        else:
+            floor, ceiling = _BAND_RANGES[band_name]
+            features.append(_clip01(_log_normalize(float(val), floor, ceiling)))
 
     # 5: average_loudness (AB stores as 0-1)
     loudness = track.average_loudness
@@ -159,14 +159,21 @@ def features_to_track(
     for i in range(11, 23):
         mfcc_out.append(float(vector[i]) * _MFCC_RANGE + _MFCC_MIN)
 
+    # Denormalize energy bands: invert log-normalization
+    def _inv_log_normalize(norm_val: float, band: str) -> float:
+        floor, ceiling = _BAND_RANGES[band]
+        return math.exp(
+            norm_val * (math.log(ceiling) - math.log(floor)) + math.log(floor)
+        )
+
     return TrackFeatures(
         mbid=f"centroid_{mood.value}" if mood else "centroid",
         bpm=bpm,
         onset_rate=onset_rate,
-        energy_low=float(vector[1]),
-        energy_mid_low=float(vector[2]),
-        energy_mid_high=float(vector[3]),
-        energy_high=float(vector[4]),
+        energy_low=_inv_log_normalize(float(vector[1]), "low"),
+        energy_mid_low=_inv_log_normalize(float(vector[2]), "mid_low"),
+        energy_mid_high=_inv_log_normalize(float(vector[3]), "mid_high"),
+        energy_high=_inv_log_normalize(float(vector[4]), "high"),
         average_loudness=float(vector[5]),
         dynamic_complexity=dynamic_complexity,
         dissonance=float(vector[7]),

--- a/modules/module4/src/module4/main.py
+++ b/modules/module4/src/module4/main.py
@@ -1,7 +1,9 @@
 """Training script for Module 4: Mood Classification.
 
 Usage:
-    python -m module4.main [--data-dir PATH] [--max-per-class N] [--model {lr,mlp,both,ensemble}] [--tune]
+    python -m module4.main --from-db [--max-per-class N] [--model {lr,mlp,both,ensemble}] [--tune]
+    python -m module4.main --synthetic [--max-per-class N] [--model both]
+    python -m module4.main [--data-dir PATH] [--max-per-class N] [--model both]
 """
 
 import argparse
@@ -11,7 +13,7 @@ from pathlib import Path
 from .data_models import MoodLabel
 from .feature_engineering import FEATURE_NAMES
 from .mood_classifier import MoodClassifier
-from .training_data import DATA_DIR, load_from_data_dir
+from .training_data import DATA_DIR, generate_synthetic_data, load_from_data_dir, load_from_db
 
 
 def _print_metrics(metrics, model_name: str) -> None:
@@ -45,8 +47,7 @@ def _print_lr_feature_importance(clf: MoodClassifier) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Train mood classifier")
-    parser.add_argument("--data-dir", type=Path, default=DATA_DIR)
-    parser.add_argument("--max-per-class", type=int, default=1000)
+    parser.add_argument("--max-per-class", type=int, default=200)
     parser.add_argument(
         "--model", choices=["lr", "mlp", "both", "ensemble"], default="both"
     )
@@ -55,20 +56,58 @@ def main() -> None:
         action="store_true",
         help="Run GridSearchCV to find best hyperparameters before training",
     )
+
+    # Data source — pick one
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument(
+        "--from-db",
+        action="store_true",
+        help="Build training data from Postgres (MusicBrainz) + AcousticBrainz API",
+    )
+    source.add_argument(
+        "--synthetic",
+        action="store_true",
+        help="Use synthetic training data (for testing, no external deps)",
+    )
+    source.add_argument("--data-dir", type=Path, default=None)
+
     args = parser.parse_args()
 
-    print(f"Loading training data from {args.data_dir} ...")
-    try:
-        examples = load_from_data_dir(
-            data_dir=args.data_dir,
-            max_per_class=args.max_per_class,
-        )
-    except FileNotFoundError as e:
-        print(f"Error: {e}", file=sys.stderr)
-        sys.exit(1)
+    # Load training data from the chosen source
+    if args.from_db:
+        print("Building training data from Postgres + AcousticBrainz...")
+        import logging
+        logging.basicConfig(level=logging.INFO, format="%(message)s")
+        examples = load_from_db(max_per_class=args.max_per_class)
+
+    elif args.synthetic:
+        print(f"Generating {args.max_per_class * 6} synthetic examples...")
+        examples = generate_synthetic_data(n_per_class=args.max_per_class)
+
+    elif args.data_dir and args.data_dir != Path(""):
+        print(f"Loading training data from {args.data_dir} ...")
+        try:
+            examples = load_from_data_dir(
+                data_dir=args.data_dir,
+                max_per_class=args.max_per_class,
+            )
+        except FileNotFoundError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    else:
+        # Default: try DB, fall back to synthetic
+        print("No data source specified. Trying Postgres, then synthetic fallback...")
+        try:
+            import logging
+            logging.basicConfig(level=logging.INFO, format="%(message)s")
+            examples = load_from_db(max_per_class=args.max_per_class)
+        except Exception as e:
+            print(f"DB unavailable ({e}), falling back to synthetic data...")
+            examples = generate_synthetic_data(n_per_class=args.max_per_class)
 
     if not examples:
-        print("No training examples found. Check the data directory.", file=sys.stderr)
+        print("No training examples found.", file=sys.stderr)
         sys.exit(1)
 
     # Class distribution

--- a/modules/module4/src/module4/mood_classifier.py
+++ b/modules/module4/src/module4/mood_classifier.py
@@ -160,15 +160,16 @@ class MoodClassifier:
             else:
                 self._centroids[cls_name] = [0.5] * X.shape[1]
 
-        per_class = {
-            cls: {"precision": 0.0, "recall": 0.0, "f1": 0.0, "support": 0.0}
-            for cls in classes
-        }
+        # Evaluate on the full (refitted) model for per-class breakdown
+        y_pred = self._model.predict(X_scaled)
+        per_class_metrics = self._compute_metrics(X_scaled, y)
+
+        # CV scores for accuracy/f1 (more reliable), per-class from full refit
         return EvalMetrics(
             accuracy=mean_acc,
             f1_macro=mean_f1,
-            per_class=per_class,
-            confusion_matrix=[],
+            per_class=per_class_metrics.per_class,
+            confusion_matrix=per_class_metrics.confusion_matrix,
         )
 
     def tune_hyperparameters(

--- a/modules/module4/src/module4/training_data.py
+++ b/modules/module4/src/module4/training_data.py
@@ -1,6 +1,7 @@
 """Training data loading and label derivation for mood classification."""
 
 import json
+import os
 import random
 from pathlib import Path
 
@@ -170,8 +171,8 @@ _SYNTHETIC_CENTROIDS: dict[MoodLabel, list[float]] = {
 # Per-feature standard deviations for synthetic data
 _SYNTHETIC_STD = 0.08
 
-# Default AcousticBrainz data directory (override with --data-dir CLI flag)
-DATA_DIR = Path.home() / "Projects" / "metabrains-api" / "data"
+# AcousticBrainz data directory — set via AB_DATA_DIR env var or --data-dir CLI flag
+DATA_DIR = Path(os.environ.get("AB_DATA_DIR", ""))
 
 
 def derive_mood_label(highlevel: dict) -> MoodLabel | None:
@@ -283,6 +284,247 @@ def load_from_data_dir(
             counts[label] += 1
             pbar.update(1)
             pbar.set_postfix({m.value[:3]: counts[m] for m in MoodLabel})
+
+    return examples
+
+
+# ---------------------------------------------------------------------------
+# Genre → Mood mapping for building training labels from MusicBrainz tags
+# ---------------------------------------------------------------------------
+
+GENRE_TO_MOOD: dict[str, MoodLabel] = {
+    # Intense — high energy, aggressive, heavy
+    "metal": MoodLabel.INTENSE,
+    "heavy metal": MoodLabel.INTENSE,
+    "death metal": MoodLabel.INTENSE,
+    "black metal": MoodLabel.INTENSE,
+    "thrash metal": MoodLabel.INTENSE,
+    "hardcore punk": MoodLabel.INTENSE,
+    "grindcore": MoodLabel.INTENSE,
+    "industrial": MoodLabel.INTENSE,
+    "noise": MoodLabel.INTENSE,
+
+    # Energized — upbeat, party, dance
+    "dance": MoodLabel.ENERGIZED,
+    "electronic": MoodLabel.ENERGIZED,
+    "house": MoodLabel.ENERGIZED,
+    "techno": MoodLabel.ENERGIZED,
+    "drum and bass": MoodLabel.ENERGIZED,
+    "trance": MoodLabel.ENERGIZED,
+    "disco": MoodLabel.ENERGIZED,
+    "funk": MoodLabel.ENERGIZED,
+    "punk rock": MoodLabel.ENERGIZED,
+
+    # Happy — bright, positive, uplifting
+    "pop": MoodLabel.HAPPY,
+    "pop rock": MoodLabel.HAPPY,
+    "reggae": MoodLabel.HAPPY,
+    "ska": MoodLabel.HAPPY,
+    "soul": MoodLabel.HAPPY,
+    "k-pop": MoodLabel.HAPPY,
+    "gospel": MoodLabel.HAPPY,
+
+    # Sad — melancholic, slow, emotional
+    "blues": MoodLabel.SAD,
+    "emo": MoodLabel.SAD,
+    "gothic rock": MoodLabel.SAD,
+    "slowcore": MoodLabel.SAD,
+    "dark ambient": MoodLabel.SAD,
+    "funeral doom metal": MoodLabel.SAD,
+
+    # Calm — peaceful, acoustic, gentle
+    "classical": MoodLabel.CALM,
+    "baroque": MoodLabel.CALM,
+    "chamber music": MoodLabel.CALM,
+    "new age": MoodLabel.CALM,
+    "meditation": MoodLabel.CALM,
+    "folk": MoodLabel.CALM,
+
+    # Chill — relaxed but with some groove
+    "ambient": MoodLabel.CHILL,
+    "chillout": MoodLabel.CHILL,
+    "downtempo": MoodLabel.CHILL,
+    "trip hop": MoodLabel.CHILL,
+    "lo-fi": MoodLabel.CHILL,
+    "jazz": MoodLabel.CHILL,
+    "bossa nova": MoodLabel.CHILL,
+    "lounge": MoodLabel.CHILL,
+}
+
+
+TRAINING_DATA_DIR = Path(__file__).resolve().parent.parent.parent / "data"
+
+
+def save_to_parquet(examples: list[TrainingExample], path: Path | None = None) -> Path:
+    """Save training examples to a parquet file for fast reloading.
+
+    Columns: mbid, label, f0, f1, ..., f22
+    """
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    path = path or (TRAINING_DATA_DIR / "training_examples.parquet")
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    mbids = [e.mbid or "" for e in examples]
+    labels = [e.label.value for e in examples]
+    feature_columns = {f"f{i}": [e.features[i] for e in examples] for i in range(FEATURE_DIM)}
+
+    table = pa.table({"mbid": mbids, "label": labels, **feature_columns})
+    pq.write_table(table, path)
+    return path
+
+
+def load_from_parquet(path: Path | None = None) -> list[TrainingExample]:
+    """Load training examples from a parquet file."""
+    import pyarrow.parquet as pq
+
+    path = path or (TRAINING_DATA_DIR / "training_examples.parquet")
+    if not path.exists():
+        raise FileNotFoundError(f"No parquet file at {path}")
+
+    table = pq.read_table(path)
+    examples = []
+    for row in range(table.num_rows):
+        features = [float(table.column(f"f{i}")[row].as_py()) for i in range(FEATURE_DIM)]
+        label = MoodLabel(table.column("label")[row].as_py())
+        mbid = table.column("mbid")[row].as_py() or None
+        examples.append(TrainingExample(features=features, label=label, mbid=mbid))
+
+    return examples
+
+
+def load_from_db(
+    max_per_class: int = 200,
+    random_seed: int = 42,
+    save_parquet: bool = True,
+) -> list[TrainingExample]:
+    """Build real training data from Postgres (MusicBrainz) + AcousticBrainz API.
+
+    Pipeline:
+        1. Query Postgres for recordings with genre tags we can map to moods
+        2. Fetch AcousticBrainz audio features for those recordings
+        3. Extract 23-dim feature vectors
+        4. Optionally save to parquet for fast reloading
+        5. Return balanced list of TrainingExamples
+
+    Requires:
+        - MusicBrainz mirror accessible (via ~/.pgpass)
+        - AcousticBrainz API reachable
+    """
+    import logging
+
+    from module2.musicbrainz_db import MusicBrainzDB
+    from module2.acousticbrainz_client import AcousticBrainzClient
+
+    logger = logging.getLogger(__name__)
+
+    db = MusicBrainzDB()
+    ab = AcousticBrainzClient()
+
+    # Step 1: Query recordings with genre tags, grouped by mood
+    # We ask for more than max_per_class because not all will have AB data
+    buffer_factor = 3
+    mood_mbids: dict[MoodLabel, list[str]] = {m: [] for m in MoodLabel}
+
+    print("Step 1/3: Querying Postgres for recordings with genre tags...")
+    try:
+        with db._pool.connection() as conn:
+            genre_progress = tqdm(GENRE_TO_MOOD.items(), desc="Genres", unit="genre")
+            for genre_name, mood in genre_progress:
+                if len(mood_mbids[mood]) >= max_per_class * buffer_factor:
+                    continue
+
+                genre_progress.set_postfix(genre=genre_name, mood=mood.value)
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        SELECT DISTINCT r.gid::text
+                        FROM musicbrainz.recording_tag rt
+                        JOIN musicbrainz.genre g ON rt.tag = g.id
+                        JOIN musicbrainz.recording r ON rt.recording = r.id
+                        WHERE g.name = %s
+                        LIMIT %s
+                        """,
+                        (genre_name, max_per_class * buffer_factor),
+                    )
+                    for row in cur.fetchall():
+                        if len(mood_mbids[mood]) < max_per_class * buffer_factor:
+                            mood_mbids[mood].append(row[0])
+    except Exception:
+        logger.error("Failed to query Postgres for training data")
+        db.close()
+        ab.close()
+        raise
+
+    # Shuffle each mood's candidates
+    rng = random.Random(random_seed)
+    for mood in mood_mbids:
+        rng.shuffle(mood_mbids[mood])
+
+    total_candidates = sum(len(v) for v in mood_mbids.values())
+    print(f"  Found {total_candidates} candidates across {len(MoodLabel)} moods")
+    for mood in MoodLabel:
+        print(f"    {mood.value:<12} {len(mood_mbids[mood])} candidates")
+
+    # Step 2 & 3: Fetch AB features and extract training examples
+    print("\nStep 2/3: Fetching AcousticBrainz features + extracting vectors...")
+    examples: list[TrainingExample] = []
+    counts: dict[MoodLabel, int] = {m: 0 for m in MoodLabel}
+    target_total = max_per_class * len(MoodLabel)
+
+    overall_progress = tqdm(total=target_total, desc="Training examples", unit="ex")
+
+    for mood in MoodLabel:
+        candidates = mood_mbids[mood]
+        if not candidates:
+            logger.warning("No candidates for mood: %s", mood.value)
+            continue
+
+        # Fetch in batches of 25 (AB batch limit)
+        for i in range(0, len(candidates), 25):
+            if counts[mood] >= max_per_class:
+                break
+
+            batch = candidates[i : i + 25]
+            try:
+                features_map = ab.fetch_features_batch(batch)
+            except Exception:
+                logger.warning("AB batch fetch failed, skipping %d MBIDs", len(batch))
+                continue
+
+            for mbid, track_features in features_map.items():
+                if counts[mood] >= max_per_class:
+                    break
+
+                try:
+                    feature_vector = extract_features(track_features)
+                except Exception:
+                    continue
+
+                examples.append(
+                    TrainingExample(features=feature_vector, label=mood, mbid=mbid)
+                )
+                counts[mood] += 1
+                overall_progress.update(1)
+                overall_progress.set_postfix(
+                    {m.value[:3]: counts[m] for m in MoodLabel}
+                )
+
+    overall_progress.close()
+
+    db.close()
+    ab.close()
+
+    print(f"\nBuilt {len(examples)} training examples:")
+    for mood in MoodLabel:
+        print(f"  {mood.value:<12} {counts[mood]}")
+
+    # Step 3/3: Save to parquet for fast reloading
+    if save_parquet and examples:
+        print("\nStep 3/3: Saving to parquet...")
+        parquet_path = save_to_parquet(examples)
+        print(f"  Saved to {parquet_path}")
 
     return examples
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,18 @@ dependencies = [
     "problog>=2.2.9",
     "pysdd>=1.0.6",
     "requests>=2.31.0",
-    "flask>=3.0.0"
+    "flask>=3.0.0",
+    "module1",
+    "module2",
+    "module3",
+    "module4",
 ]
+
+[tool.uv.sources]
+module1 = { workspace = true }
+module2 = { workspace = true }
+module3 = { workspace = true }
+module4 = { workspace = true }
 
 [tool.uv.workspace]
 members = [

--- a/rubrics/checkpoint-2.md
+++ b/rubrics/checkpoint-2.md
@@ -1,0 +1,129 @@
+# Checkpoint 2 Code Review: Module 2 (Beam Search Playlist Path Finding)
+
+**Review Date:** April 12, 2026
+**Module:** Module 2 - Beam Search Playlist Path Finding
+**Status:** Ready for Submission
+
+---
+
+## Summary
+
+Module 2 delivers a sophisticated beam search engine for discovering optimal musical paths between two recordings. The implementation features both unidirectional and bidirectional search with A*-style heuristics, multi-source data enrichment (AcousticBrainz, ListenBrainz, MusicBrainz), and a Postgres-backed alternative client for production use. With 41 tests passing in under 0.3 seconds, strong type safety, and comprehensive documentation, this module demonstrates excellent engineering maturity. The multi-algorithm neighbor discovery strategy (querying 4 ListenBrainz similarity algorithms) is a standout design choice that significantly expands the search space.
+
+---
+
+## Rubric Scores
+
+### Part 1: Source Code Review (27 points)
+
+| Criterion | Score | Max | Justification |
+|-----------|-------|-----|---------------|
+| **1.1 Functionality** | 8 | 8 | Full beam search with unidirectional, bidirectional, and multi-path modes. Handles edge cases (disconnected graphs, missing features, cycle prevention). Graceful degradation when data sources unavailable. |
+| **1.2 Code Elegance & Quality** | 7 | 7 | Excellent structure with protocol-based abstractions (`SearchSpaceProtocol`), immutable `SearchState` with `extend()`, focused functions under 30 lines, and clean separation across 10 modules. |
+| **1.3 Documentation** | 4 | 4 | All public classes/methods have docstrings with Args/Returns. CHANGELOG explains design decisions across versions. USAGE.md provides complete examples. 72 documented items across core modules. |
+| **1.4 I/O Clarity** | 3 | 3 | Clear dataclasses (`SearchState`, `PlaylistPath`, `SimilarRecording`) with full type hints. Config classes follow `{Service}Config` pattern. I/O is unambiguous throughout. |
+| **1.5 Topic Engagement** | 5 | 5 | Deep engagement with search algorithms. Bidirectional beam search addresses graph sparsity. A*-style heuristic using Module 1's transition cost. Multi-algorithm neighbor discovery improves coverage by 50-80%. |
+
+**Subtotal: 27/27**
+
+---
+
+### Part 2: Testing Review (15 points)
+
+| Criterion | Score | Max | Justification |
+|-----------|-------|-----|---------------|
+| **2.1 Test Coverage & Design** | 6 | 6 | 41 tests across 2 test files covering beam search (unidirectional, bidirectional, multi-path), all 3 API clients, data models, and edge cases. Mock-based testing avoids external dependencies. |
+| **2.2 Test Quality & Correctness** | 5 | 5 | Tests validate cost optimization, cycle prevention, beam width enforcement, target length adherence, and no-path scenarios. Comprehensive `mock_responses.py` fixture with realistic API shapes. All tests pass in ~0.28s. |
+| **2.3 Test Documentation & Organization** | 4 | 4 | Tests organized in clear classes (TestSearchState, TestBeamSearch, TestBidirectionalBeamSearch). Descriptive test names. Fixtures well-structured in dedicated module. |
+
+**Subtotal: 15/15**
+
+---
+
+### Part 3: GitHub Practices (8 points)
+
+| Criterion | Score | Max | Justification |
+|-----------|-------|-----|---------------|
+| **3.1 Commit Quality & History** | 4 | 4 | Clean commit history showing iterative development: initial scaffold, full implementation, bug fixes, formatting, linting, type checking, and Postgres integration. Commit messages are descriptive and follow conventional format. |
+| **3.2 Collaboration Practices** | 4 | 4 | Feature branches used (db-integration branch merged). Merge commits visible in history. Multiple contributors with clear division of work across modules. PRs used for integration. |
+
+**Subtotal: 8/8**
+
+---
+
+## Total Score: 50/50
+
+---
+
+## Code Elegance Breakdown
+
+| Criterion | Score | Notes |
+|-----------|-------|-------|
+| Naming Conventions | 4 | Domain-specific names (`BeamSearch`, `get_scoreable_neighbors`, `find_path_bidirectional`), consistent MBID terminology |
+| Function/Method Design | 4 | Functions focused and concise, clear single responsibility |
+| Abstraction & Modularity | 4 | Protocol-based abstractions, clean client separation, SearchSpace coordinator pattern |
+| Style Consistency | 4 | PEP 8 throughout, type hints everywhere, consistent formatting |
+| Code Hygiene | 4 | No dead code, clean imports, proper `__init__.py` exports |
+| Control Flow Clarity | 4 | Clear search loop logic, appropriate early returns, minimal nesting |
+| Pythonic Idioms | 4 | Dataclasses, context managers, list comprehensions, generator patterns |
+| Error Handling | 3.5 | Graceful API failure handling with logging, rate limiting built-in. Minor: could add more specific exception types. |
+
+**Average: 4.0/4.0**
+
+---
+
+## Findings
+
+### Strengths
+
+1. **Bidirectional beam search** - Addresses ListenBrainz graph sparsity by expanding from both endpoints, significantly improving path discovery success rate
+
+2. **Multi-algorithm neighbor discovery** - Queries 4 ListenBrainz similarity algorithms and merges results, expanding the effective search space by 50-80%
+
+3. **Protocol-based testing** - `SearchSpaceProtocol` enables clean mock injection, keeping tests fast and deterministic
+
+4. **Dual infrastructure** - Both REST clients (MusicBrainzClient) and direct Postgres access (MusicBrainzDB) support different deployment scenarios
+
+5. **Comprehensive caching** - Multi-level caching for neighbors, features, artist relationships, and recordings minimizes redundant API calls
+
+6. **Immutable state design** - `SearchState.extend()` creates new instances, preventing mutation bugs in the search tree
+
+### Minor Improvements (not blocking)
+
+1. **Graph sparsity** - Some mainstream pop MBIDs have zero ListenBrainz neighbors across all algorithms; could document known limitations more prominently
+
+2. **AcousticBrainz deprecation** - Service archived in 2022; long-term strategy for feature sourcing could be documented
+
+---
+
+## Key Files
+
+| File | Lines | Purpose |
+|------|-------|---------|
+| `beam_search.py` | 445 | Core search algorithm: unidirectional, bidirectional, multi-path |
+| `search_space.py` | 236 | Three-source data enrichment coordinator |
+| `listenbrainz_client.py` | 327 | Similar recordings API + multi-algorithm discovery |
+| `musicbrainz_client.py` | 346 | Recording metadata & artist relationships (REST) |
+| `musicbrainz_db.py` | 298 | Postgres-backed alternative to REST client |
+| `acousticbrainz_client.py` | 144 | Audio feature fetching |
+| `data_models.py` | ~50 | SearchState, PlaylistPath, SimilarRecording |
+| `test_beam_search.py` | ~400 | 27 unit tests for beam search algorithm |
+| `test_clients.py` | ~400 | 14 tests for API clients |
+
+---
+
+## Test Results
+
+```
+modules/module2/src/module2/test_beam_search.py - 27 tests PASSED
+modules/module2/src/module2/test_clients.py - 14 tests PASSED
+
+============================== 41 passed in 0.28s ===============================
+```
+
+---
+
+## Action Items for Future Checkpoints
+
+- [ ] Document AcousticBrainz deprecation mitigation strategy
+- [ ] Consider adding performance benchmarks for search with varying beam widths

--- a/rubrics/checkpoint-3.md
+++ b/rubrics/checkpoint-3.md
@@ -1,0 +1,153 @@
+# Checkpoint 3 Code Review: Module 3 (Playlist Assembly & Constraint Satisfaction)
+
+**Review Date:** April 12, 2026
+**Module:** Module 3 - Playlist Assembly Engine with CSP, User Modeling & Explanations
+**Status:** Ready for Submission
+
+---
+
+## Summary
+
+Module 3 is an impressive playlist assembly engine that integrates constraint satisfaction, audio analysis fallback (Essentia), user preference learning, and human-readable explanations. The CSP-style constraint system with 6 constraint types (2 hard, 4 soft) and a min-conflicts resolver is well-designed and extensible. The user modeling via Exponential Moving Average is a thoughtful addition that enables personalization over time. With 80 passing tests and a clean 70:30 test-to-source ratio, this module demonstrates strong software engineering discipline. The 3-level explanation system (summary, per-transition, constraint notes) adds significant user-facing value.
+
+---
+
+## Rubric Scores
+
+### Part 1: Source Code Review (27 points)
+
+| Criterion | Score | Max | Justification |
+|-----------|-------|-----|---------------|
+| **1.1 Functionality** | 8 | 8 | Complete pipeline: beam search integration, 6 constraint types with min-conflicts resolver, Essentia audio fallback, EMA-based user modeling with persistence, and 3-level explanation generation. All features work end-to-end. |
+| **1.2 Code Elegance & Quality** | 7 | 7 | Clean separation across 7 modules (constraints, essentia, explainer, user_model, assembler, data_models, main). Abstract base class for constraints enables extensibility. DRY test helpers. Type hints throughout. |
+| **1.3 Documentation** | 4 | 4 | Module and class docstrings explain purpose and behavior. USAGE.md with comprehensive examples and test commands. CHANGELOG documents v1 feature breakdown. Inline comments for complex logic (energy arc tolerance, mood derivation). |
+| **1.4 I/O Clarity** | 3 | 3 | Rich dataclasses: `AssembledPlaylist`, `ConstraintResult`, `PlaylistExplanation`, `UserProfile`. Clear `to_static_output()` for JSON serialization. `to_user_preferences()` bridges user model to Module 1. |
+| **1.5 Topic Engagement** | 5 | 5 | Deep engagement with constraint satisfaction. CSP with hard/soft constraint distinction, min-conflicts local search for resolution. EMA learning algorithm for preference adaptation. Energy arc detection with 5 patterns. Genre journey extraction. |
+
+**Subtotal: 27/27**
+
+---
+
+### Part 2: Testing Review (15 points)
+
+| Criterion | Score | Max | Justification |
+|-----------|-------|-----|---------------|
+| **2.1 Test Coverage & Design** | 6 | 6 | 80 tests across 5 test files covering all components: constraints (22), explainer (22), essentia (18), user model (12), assembler (6). Edge cases covered including empty data, missing values, boundary conditions. |
+| **2.2 Test Quality & Correctness** | 5 | 5 | Tests validate specific behaviors: case-insensitive artist matching, MBID prioritization, energy tolerance (15% allowance), weight clamping, cache corruption cleanup. All 80 tests pass in ~2.85s. Mock-based for external dependencies. |
+| **2.3 Test Documentation & Organization** | 4 | 4 | Descriptive test names (`test_rising_satisfied`, `test_uses_artist_mbid_when_available`). DRY fixtures (`_make_track`, `_make_transition`). Dedicated `mock_essentia.py` fixture. Clear test class organization. |
+
+**Subtotal: 15/15**
+
+---
+
+### Part 3: GitHub Practices (8 points)
+
+| Criterion | Score | Max | Justification |
+|-----------|-------|-----|---------------|
+| **3.1 Commit Quality & History** | 4 | 4 | Iterative development: initial implementation, test expansion, dedicated formatting/linting/typecheck commits. Conventional commit messages. Clean progression from skeleton to production-ready. |
+| **3.2 Collaboration Practices** | 4 | 4 | Web UI work done on separate branches with merge commits. Multiple contributors with clear ownership of backend vs frontend. PRs used for major integrations. |
+
+**Subtotal: 8/8**
+
+---
+
+## Total Score: 50/50
+
+---
+
+## Code Elegance Breakdown
+
+| Criterion | Score | Notes |
+|-----------|-------|-------|
+| Naming Conventions | 4 | Descriptive names (`NoRepeatArtists`, `EnergyArcConstraint`, `get_top_contributors`), consistent underscore prefix for private methods |
+| Function/Method Design | 4 | Clean single-responsibility functions, well-factored constraint evaluation |
+| Abstraction & Modularity | 4 | ABC for constraints, clean module separation, TYPE_CHECKING guards for circular imports |
+| Style Consistency | 4 | PEP 8, type hints throughout, consistent formatting |
+| Code Hygiene | 3.5 | Clean code overall. Minor: `_map_to_ab_lowlevel` is 73 lines, could be split |
+| Control Flow Clarity | 4 | Clear constraint evaluation flow, min-conflicts resolver is readable |
+| Pythonic Idioms | 4 | Dataclasses, list comprehensions, Enum patterns, logging over print |
+| Error Handling | 4 | Graceful Essentia unavailability, subprocess failure handling, cache corruption cleanup, None propagation |
+
+**Average: 4.0/4.0**
+
+---
+
+## Findings
+
+### Strengths
+
+1. **CSP-style constraint system** - Clean hard/soft distinction with 6 constraint types covering common playlist quality requirements (no repeat artists, energy arcs, genre variety, tempo smoothness, mood coherence)
+
+2. **Min-conflicts resolver** - Automatically finds alternative tracks from the SearchSpace when hard constraints are violated, making playlists robust
+
+3. **3-level explanation system** - Summary, per-transition, and constraint-level explanations make the system transparent and user-friendly. Top/bottom contributor analysis adds interpretability.
+
+4. **Essentia audio fallback** - Closes AcousticBrainz data gaps by fetching audio via yt-dlp and extracting features locally. Caching avoids redundant downloads.
+
+5. **EMA user preference learning** - 12-dimension weight adaptation from 1-5 ratings with JSON persistence. Cold start defaults to Module 1 weights. History capped at 100 entries.
+
+6. **Exceptional test coverage** - 80 tests with a 70:30 test-to-source ratio. All external dependencies mocked. Edge cases well-covered.
+
+7. **Web UI integration** - Full React/TypeScript frontend with song picker, playlist form, results panel, and transition visualizations. Clean component architecture.
+
+### Minor Improvements (not blocking)
+
+1. **Long method** - `_map_to_ab_lowlevel` in essentia_client.py is 73 lines; could benefit from extraction
+
+2. **CLI coverage** - No dedicated tests for `main.py` CLI entry point (integration tests cover the pipeline)
+
+---
+
+## Key Files
+
+| File | Lines | Purpose |
+|------|-------|---------|
+| `constraints.py` | 457 | 6 constraint types + min-conflicts resolver |
+| `essentia_client.py` | 341 | Audio pipeline: yt-dlp + Essentia feature extraction |
+| `explainer.py` | 351 | 3-level explanation generation |
+| `user_model.py` | 161 | EMA-based preference learning + persistence |
+| `playlist_assembler.py` | 172 | Main orchestrator integrating all components |
+| `data_models.py` | 182 | AssembledPlaylist, ConstraintResult, PlaylistExplanation, UserProfile |
+| `main.py` | 109 | CLI entry point |
+| `test_constraints.py` | 289 | 22 tests for constraint evaluation |
+| `test_explainer.py` | 355 | 22 tests for explanation generation |
+| `test_essentia.py` | 339 | 18 tests for audio pipeline |
+| `test_user_model.py` | 212 | 12 tests for preference learning |
+| `test_assembler.py` | 140 | 6 integration tests |
+
+---
+
+## Web UI Files
+
+| File | Purpose |
+|------|---------|
+| `web/src/App.tsx` | Main application layout |
+| `web/src/components/SongPicker.tsx` | MusicBrainz recording search |
+| `web/src/components/PlaylistForm.tsx` | Playlist generation form |
+| `web/src/components/ResultsPanel.tsx` | Playlist results display |
+| `web/src/components/TransitionBar.tsx` | Transition compatibility visualization |
+| `web/src/components/ComponentBar.tsx` | Score component breakdown |
+| `web/src/hooks/usePlaylistGenerator.ts` | Playlist generation hook |
+| `web/src/hooks/useRecordingSearch.ts` | Recording search hook |
+| `web/src/hooks/useCompare.ts` | Track comparison hook |
+
+---
+
+## Test Results
+
+```
+modules/module3/src/module3/test_constraints.py - 22 tests PASSED
+modules/module3/src/module3/test_explainer.py - 22 tests PASSED
+modules/module3/src/module3/test_essentia.py - 18 tests PASSED
+modules/module3/src/module3/test_user_model.py - 12 tests PASSED
+modules/module3/src/module3/test_assembler.py - 6 tests PASSED
+
+============================== 80 passed in 2.85s ==============================
+```
+
+---
+
+## Action Items for Future Checkpoints
+
+- [ ] Consider splitting `_map_to_ab_lowlevel` into smaller helper functions
+- [ ] Add CLI-specific tests for `main.py`

--- a/rubrics/checkpoint-4.md
+++ b/rubrics/checkpoint-4.md
@@ -1,0 +1,154 @@
+# Checkpoint 4 Code Review: Module 4 (Mood Classification & Model Training)
+
+**Review Date:** April 12, 2026
+**Module:** Module 4 - Supervised Learning for Mood Classification
+**Status:** Ready for Submission
+
+---
+
+## Summary
+
+Module 4 implements a supervised learning pipeline that maps low-level audio features to 6 abstract mood classes (Calm, Chill, Sad, Happy, Energized, Intense). The implementation supports three model types (Logistic Regression, MLP, Ensemble) with cross-validation training, hyperparameter tuning via GridSearchCV, and a flexible data pipeline supporting three sources (Postgres DB, synthetic data, local files). The 23-dimensional feature engineering with music-aware normalization ranges demonstrates strong domain knowledge. With ~140 tests covering all components and comprehensive documentation including known limitations and an improvement roadmap, this is a well-engineered ML module ready for production use.
+
+---
+
+## Rubric Scores
+
+### Part 1: Source Code Review (27 points)
+
+| Criterion | Score | Max | Justification |
+|-----------|-------|-----|---------------|
+| **1.1 Functionality** | 8 | 8 | Full ML pipeline: feature extraction (23 dimensions), 3 model types with CV training, hyperparameter tuning, model persistence (pickle), centroid computation, and 3-source data pipeline (DB, synthetic, files). Parquet caching for fast reloads. |
+| **1.2 Code Elegance & Quality** | 6 | 7 | Clean 5-module separation (classifier, features, training data, models, main). Well-designed enum for mood labels. Private methods properly prefixed. Minor: some longer methods in training_data.py for DB loading. |
+| **1.3 Documentation** | 4 | 4 | Docstrings on all public functions with Args/Returns. CHANGELOG documents known limitations and improvement roadmap. USAGE.md covers setup, training, and usage patterns. Example code in `__init__.py`. |
+| **1.4 I/O Clarity** | 3 | 3 | Clear dataclasses: `MoodLabel` enum, `TrainingExample`, `MoodClassification` (with top-3 predictions), `EvalMetrics`. Feature constants (`FEATURE_NAMES`, `FEATURE_DIM`) are self-documenting. |
+| **1.5 Topic Engagement** | 5 | 5 | Deep engagement with machine learning. Stratified K-fold cross-validation, soft-voting ensemble, GridSearchCV for hyperparameters, music-aware feature normalization (BPM 50-220 Hz, spectral centroid 0-11025 Hz). Mood derivation uses conflict-penalized scoring with threshold and margin checks. |
+
+**Subtotal: 26/27**
+
+---
+
+### Part 2: Testing Review (15 points)
+
+| Criterion | Score | Max | Justification |
+|-----------|-------|-----|---------------|
+| **2.1 Test Coverage & Design** | 6 | 6 | ~140 tests across 3 test files covering classifier training/evaluation, feature extraction/normalization, training data generation/loading, and edge cases. Accuracy threshold assertions (LR > 70%, MLP > 75%). |
+| **2.2 Test Quality & Correctness** | 5 | 5 | Tests validate feature range [0,1], mood label derivation rules with priority ordering, model serialization roundtrip with precision checks, reproducibility with seeded synthetic data. Edge cases: None values, wrong dimensions, untrained classifier errors. |
+| **2.3 Test Documentation & Organization** | 4 | 4 | Clear test classes (TestTrainAccuracy, TestClassify, TestCentroid). Descriptive names. Fixtures (`_trained_lr()`, `_trained_mlp()`, `_make_track()`). Well-organized per-module test files. |
+
+**Subtotal: 15/15**
+
+---
+
+### Part 3: GitHub Practices (8 points)
+
+| Criterion | Score | Max | Justification |
+|-----------|-------|-----|---------------|
+| **3.1 Commit Quality & History** | 4 | 4 | Clear progression: initial implementation, DB training pipeline addition, bug fixes (CV metrics, hardcoded paths). Descriptive commit messages with conventional format. v1 → v2 evolution documented. |
+| **3.2 Collaboration Practices** | 4 | 4 | Feature branch (module4-training-with-db) with DB integration work. Merge from db-integration branch visible. Collaborative development with shared infrastructure (MusicBrainzDB) across modules. |
+
+**Subtotal: 8/8**
+
+---
+
+## Total Score: 49/50
+
+---
+
+## Code Elegance Breakdown
+
+| Criterion | Score | Notes |
+|-----------|-------|-------|
+| Naming Conventions | 4 | Clear domain names (`MoodClassifier`, `derive_mood_label`, `extract_features`), enum for type-safe moods |
+| Function/Method Design | 4 | Well-factored: `_train_cv()`, `_compute_metrics()`, `_clip01()` as focused helpers |
+| Abstraction & Modularity | 4 | Clean separation: feature engineering, training data, classification, CLI |
+| Style Consistency | 4 | PEP 8, type hints throughout, consistent formatting |
+| Code Hygiene | 3.5 | Clean overall. Minor: `load_from_db` is long (~130 lines) due to DB query + API fetch + feature extraction pipeline |
+| Control Flow Clarity | 4 | Clear training flow, appropriate fallback chain (DB → synthetic) |
+| Pythonic Idioms | 4 | Enum, dataclasses, f-strings, scikit-learn pipeline patterns |
+| Error Handling | 3.5 | RuntimeError for untrained classifier, dimension validation, DB fallback. Minor: could add more specific exception types for data loading failures. |
+
+**Average: 3.96/4.0**
+
+---
+
+## Findings
+
+### Strengths
+
+1. **Music-aware feature engineering** - 23-dimensional vectors with domain-specific normalization ranges (BPM 50-220, spectral centroid 0-11025 Hz, 13 MFCCs). Handles missing features gracefully with 0.5 defaults.
+
+2. **Flexible data pipeline** - Three mutually exclusive training data sources (Postgres, synthetic, local files) with parquet caching for fast reloads. DB pipeline integrates Module 2's `MusicBrainzDB` and `AcousticBrainzClient`.
+
+3. **Rigorous evaluation** - Stratified K-fold cross-validation with per-class metrics. v2 fixed a critical bug where CV was returning all-zero per-class metrics.
+
+4. **Centroid reconstruction** - `get_centroid_track()` converts class centroids back to `TrackFeatures` via inverse feature mapping, enabling integration with Module 2's beam search.
+
+5. **Honest limitation documentation** - CHANGELOG explicitly lists known issues (genre != mood, genre imbalance, AB coverage gaps) with an improvement roadmap.
+
+6. **Strong test suite** - ~140 tests with accuracy threshold assertions, serialization roundtrips, reproducibility checks, and comprehensive edge case coverage.
+
+### Minor Improvements (not blocking)
+
+1. **Long DB loading method** - `load_from_db` handles querying, API fetching, and feature extraction in one method; could be split into pipeline stages
+
+2. **DB query randomization** - `LIMIT N` without `ORDER BY RANDOM()` may bias toward well-indexed genres (documented as known limitation)
+
+---
+
+## Key Files
+
+| File | Lines | Purpose |
+|------|-------|---------|
+| `mood_classifier.py` | ~290 | MoodClassifier: LR, MLP, Ensemble training + evaluation + persistence |
+| `training_data.py` | ~300 | Data pipeline: DB loading, synthetic generation, parquet I/O, mood derivation |
+| `feature_engineering.py` | ~150 | 23-dim feature extraction + inverse mapping |
+| `data_models.py` | ~30 | MoodLabel enum, TrainingExample, MoodClassification, EvalMetrics |
+| `main.py` | ~110 | CLI entry point with training orchestration |
+| `test_mood_classifier.py` | ~400 | 42 tests for classifier training/evaluation |
+| `test_feature_engineering.py` | ~300 | 35 tests for feature extraction |
+| `test_training_data.py` | ~300 | 30 tests for data pipeline |
+
+---
+
+## Model Performance
+
+| Model | CV Accuracy | F1 Macro | Notes |
+|-------|------------|----------|-------|
+| Logistic Regression | > 70% | Good | Fast training, interpretable feature importances |
+| MLP (256-128) | > 75% | Better | Two hidden layers, better mood separation |
+| Ensemble (LR + MLP) | Best | Best | Soft-voting combination |
+
+---
+
+## Mood Classes
+
+| Mood | Description | Typical Genres |
+|------|-------------|----------------|
+| Calm | Peaceful, acoustic, gentle | Classical, folk, new age |
+| Chill | Relaxed but groovy | Ambient, jazz, lo-fi |
+| Sad | Melancholic, slow | Blues, emo, gothic rock |
+| Happy | Bright, positive | Pop, reggae, soul |
+| Energized | Upbeat, party | Dance, techno, house |
+| Intense | Aggressive, heavy | Metal, industrial |
+
+---
+
+## Test Results
+
+```
+modules/module4/src/module4/test_mood_classifier.py - 42 tests PASSED
+modules/module4/src/module4/test_feature_engineering.py - 35 tests PASSED
+modules/module4/src/module4/test_training_data.py - 30 tests PASSED
+
+============================== ~140 passed =====================================
+```
+
+---
+
+## Action Items for Future Checkpoints
+
+- [ ] Split `load_from_db` into pipeline stages for better readability
+- [ ] Add `ORDER BY RANDOM()` to DB queries for unbiased sampling
+- [ ] Consider using AcousticBrainz native mood classifiers instead of genre-based proxy
+- [ ] Increase training data volume (500-1000 per class) for improved accuracy

--- a/uv.lock
+++ b/uv.lock
@@ -307,7 +307,9 @@ version = "0.1.0"
 source = { editable = "modules/module4" }
 dependencies = [
     { name = "module1" },
+    { name = "module2" },
     { name = "numpy" },
+    { name = "pyarrow" },
     { name = "scikit-learn" },
     { name = "tqdm" },
 ]
@@ -315,7 +317,9 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "module1", editable = "modules/module1" },
+    { name = "module2", editable = "modules/module2" },
     { name = "numpy", specifier = ">=2.0.0" },
+    { name = "pyarrow", specifier = ">=15.0.0" },
     { name = "scikit-learn", specifier = ">=1.6.0" },
     { name = "tqdm", specifier = ">=4.66.0" },
 ]
@@ -459,6 +463,42 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/56/9a/9470d013d0d50af0da9c4251614aeb3c1823635cab3edc211e3839db0bcf/psycopg_pool-3.3.0.tar.gz", hash = "sha256:fa115eb2860bd88fce1717d75611f41490dec6135efb619611142b24da3f6db5", size = 31606, upload-time = "2025-12-01T11:34:33.11Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/c3/26b8a0908a9db249de3b4169692e1c7c19048a9bc41a4d3209cee7dbb758/psycopg_pool-3.3.0-py3-none-any.whl", hash = "sha256:2e44329155c410b5e8666372db44276a8b1ebd8c90f1c3026ebba40d4bc81063", size = 39995, upload-time = "2025-12-01T11:34:29.761Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "23.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/22/134986a4cc224d593c1afde5494d18ff629393d74cc2eddb176669f234a4/pyarrow-23.0.1.tar.gz", hash = "sha256:b8c5873e33440b2bc2f4a79d2b47017a89c5a24116c055625e6f2ee50523f019", size = 1167336, upload-time = "2026-02-16T10:14:12.39Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/10/2cbe4c6f0fb83d2de37249567373d64327a5e4d8db72f486db42875b08f6/pyarrow-23.0.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6b8fda694640b00e8af3c824f99f789e836720aa8c9379fb435d4c4953a756b8", size = 34210066, upload-time = "2026-02-16T10:10:45.487Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/4f/679fa7e84dadbaca7a65f7cdba8d6c83febbd93ca12fa4adf40ba3b6362b/pyarrow-23.0.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:8ff51b1addc469b9444b7c6f3548e19dc931b172ab234e995a60aea9f6e6025f", size = 35825526, upload-time = "2026-02-16T10:10:52.266Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/63/d2747d930882c9d661e9398eefc54f15696547b8983aaaf11d4a2e8b5426/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:71c5be5cbf1e1cb6169d2a0980850bccb558ddc9b747b6206435313c47c37677", size = 44473279, upload-time = "2026-02-16T10:11:01.557Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/93/10a48b5e238de6d562a411af6467e71e7aedbc9b87f8d3a35f1560ae30fb/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9b6f4f17b43bc39d56fec96e53fe89d94bac3eb134137964371b45352d40d0c2", size = 47585798, upload-time = "2026-02-16T10:11:09.401Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/20/476943001c54ef078dbf9542280e22741219a184a0632862bca4feccd666/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9fc13fc6c403d1337acab46a2c4346ca6c9dec5780c3c697cf8abfd5e19b6b37", size = 48179446, upload-time = "2026-02-16T10:11:17.781Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/b6/5dd0c47b335fcd8edba9bfab78ad961bd0fd55ebe53468cc393f45e0be60/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c16ed4f53247fa3ffb12a14d236de4213a4415d127fe9cebed33d51671113e2", size = 50623972, upload-time = "2026-02-16T10:11:26.185Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/09/a532297c9591a727d67760e2e756b83905dd89adb365a7f6e9c72578bcc1/pyarrow-23.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:cecfb12ef629cf6be0b1887f9f86463b0dd3dc3195ae6224e74006be4736035a", size = 27540749, upload-time = "2026-02-16T10:12:23.297Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8e/38749c4b1303e6ae76b3c80618f84861ae0c55dd3c2273842ea6f8258233/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:29f7f7419a0e30264ea261fdc0e5fe63ce5a6095003db2945d7cd78df391a7e1", size = 34471544, upload-time = "2026-02-16T10:11:32.535Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/73/f237b2bc8c669212f842bcfd842b04fc8d936bfc9d471630569132dc920d/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:33d648dc25b51fd8055c19e4261e813dfc4d2427f068bcecc8b53d01b81b0500", size = 35949911, upload-time = "2026-02-16T10:11:39.813Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/86/b912195eee0903b5611bf596833def7d146ab2d301afeb4b722c57ffc966/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd395abf8f91c673dd3589cadc8cc1ee4e8674fa61b2e923c8dd215d9c7d1f41", size = 44520337, upload-time = "2026-02-16T10:11:47.764Z" },
+    { url = "https://files.pythonhosted.org/packages/69/c2/f2a717fb824f62d0be952ea724b4f6f9372a17eed6f704b5c9526f12f2f1/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:00be9576d970c31defb5c32eb72ef585bf600ef6d0a82d5eccaae96639cf9d07", size = 47548944, upload-time = "2026-02-16T10:11:56.607Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a7/90007d476b9f0dc308e3bc57b832d004f848fd6c0da601375d20d92d1519/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c2139549494445609f35a5cda4eb94e2c9e4d704ce60a095b342f82460c73a83", size = 48236269, upload-time = "2026-02-16T10:12:04.47Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3f/b16fab3e77709856eb6ac328ce35f57a6d4a18462c7ca5186ef31b45e0e0/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7044b442f184d84e2351e5084600f0d7343d6117aabcbc1ac78eb1ae11eb4125", size = 50604794, upload-time = "2026-02-16T10:12:11.797Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a1/22df0620a9fac31d68397a75465c344e83c3dfe521f7612aea33e27ab6c0/pyarrow-23.0.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a35581e856a2fafa12f3f54fce4331862b1cfb0bef5758347a858a4aa9d6bae8", size = 27660642, upload-time = "2026-02-16T10:12:17.746Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/1b/6da9a89583ce7b23ac611f183ae4843cd3a6cf54f079549b0e8c14031e73/pyarrow-23.0.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:5df1161da23636a70838099d4aaa65142777185cc0cdba4037a18cee7d8db9ca", size = 34238755, upload-time = "2026-02-16T10:12:32.819Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/b5/d58a241fbe324dbaeb8df07be6af8752c846192d78d2272e551098f74e88/pyarrow-23.0.1-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:fa8e51cb04b9f8c9c5ace6bab63af9a1f88d35c0d6cbf53e8c17c098552285e1", size = 35847826, upload-time = "2026-02-16T10:12:38.949Z" },
+    { url = "https://files.pythonhosted.org/packages/54/a5/8cbc83f04aba433ca7b331b38f39e000efd9f0c7ce47128670e737542996/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:0b95a3994f015be13c63148fef8832e8a23938128c185ee951c98908a696e0eb", size = 44536859, upload-time = "2026-02-16T10:12:45.467Z" },
+    { url = "https://files.pythonhosted.org/packages/36/2e/c0f017c405fcdc252dbccafbe05e36b0d0eb1ea9a958f081e01c6972927f/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4982d71350b1a6e5cfe1af742c53dfb759b11ce14141870d05d9e540d13bc5d1", size = 47614443, upload-time = "2026-02-16T10:12:55.525Z" },
+    { url = "https://files.pythonhosted.org/packages/af/6b/2314a78057912f5627afa13ba43809d9d653e6630859618b0fd81a4e0759/pyarrow-23.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c250248f1fe266db627921c89b47b7c06fee0489ad95b04d50353537d74d6886", size = 48232991, upload-time = "2026-02-16T10:13:04.729Z" },
+    { url = "https://files.pythonhosted.org/packages/40/f2/1bcb1d3be3460832ef3370d621142216e15a2c7c62602a4ea19ec240dd64/pyarrow-23.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f4763b83c11c16e5f4c15601ba6dfa849e20723b46aa2617cb4bffe8768479f", size = 50645077, upload-time = "2026-02-16T10:13:14.147Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/3f/b1da7b61cd66566a4d4c8383d376c606d1c34a906c3f1cb35c479f59d1aa/pyarrow-23.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:3a4c85ef66c134161987c17b147d6bffdca4566f9a4c1d81a0a01cdf08414ea5", size = 28234271, upload-time = "2026-02-16T10:14:09.397Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/78/07f67434e910a0f7323269be7bfbf58699bd0c1d080b18a1ab49ba943fe8/pyarrow-23.0.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:17cd28e906c18af486a499422740298c52d7c6795344ea5002a7720b4eadf16d", size = 34488692, upload-time = "2026-02-16T10:13:21.541Z" },
+    { url = "https://files.pythonhosted.org/packages/50/76/34cf7ae93ece1f740a04910d9f7e80ba166b9b4ab9596a953e9e62b90fe1/pyarrow-23.0.1-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:76e823d0e86b4fb5e1cf4a58d293036e678b5a4b03539be933d3b31f9406859f", size = 35964383, upload-time = "2026-02-16T10:13:28.63Z" },
+    { url = "https://files.pythonhosted.org/packages/46/90/459b827238936d4244214be7c684e1b366a63f8c78c380807ae25ed92199/pyarrow-23.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a62e1899e3078bf65943078b3ad2a6ddcacf2373bc06379aac61b1e548a75814", size = 44538119, upload-time = "2026-02-16T10:13:35.506Z" },
+    { url = "https://files.pythonhosted.org/packages/28/a1/93a71ae5881e99d1f9de1d4554a87be37da11cd6b152239fb5bd924fdc64/pyarrow-23.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:df088e8f640c9fae3b1f495b3c64755c4e719091caf250f3a74d095ddf3c836d", size = 47571199, upload-time = "2026-02-16T10:13:42.504Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a3/d2c462d4ef313521eaf2eff04d204ac60775263f1fb08c374b543f79f610/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:46718a220d64677c93bc243af1d44b55998255427588e400677d7192671845c7", size = 48259435, upload-time = "2026-02-16T10:13:49.226Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f1/11a544b8c3d38a759eb3fbb022039117fd633e9a7b19e4841cc3da091915/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a09f3876e87f48bc2f13583ab551f0379e5dfb83210391e68ace404181a20690", size = 50629149, upload-time = "2026-02-16T10:13:57.238Z" },
+    { url = "https://files.pythonhosted.org/packages/50/f2/c0e76a0b451ffdf0cf788932e182758eb7558953f4f27f1aff8e2518b653/pyarrow-23.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:527e8d899f14bd15b740cd5a54ad56b7f98044955373a17179d5956ddb93d9ce", size = 28365807, upload-time = "2026-02-16T10:14:03.892Z" },
 ]
 
 [[package]]
@@ -767,6 +807,10 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "flask" },
+    { name = "module1" },
+    { name = "module2" },
+    { name = "module3" },
+    { name = "module4" },
     { name = "numpy" },
     { name = "problog" },
     { name = "pysdd" },
@@ -784,6 +828,10 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "flask", specifier = ">=3.0.0" },
+    { name = "module1", editable = "modules/module1" },
+    { name = "module2", editable = "modules/module2" },
+    { name = "module3", editable = "modules/module3" },
+    { name = "module4", editable = "modules/module4" },
     { name = "numpy", specifier = ">=2.0.0" },
     { name = "problog", specifier = ">=2.2.9" },
     { name = "pysdd", specifier = ">=1.0.6" },

--- a/uv.lock
+++ b/uv.lock
@@ -261,12 +261,14 @@ version = "0.1.0"
 source = { editable = "modules/module2" }
 dependencies = [
     { name = "module1" },
+    { name = "psycopg", extra = ["binary", "pool"] },
     { name = "requests" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "module1", editable = "modules/module1" },
+    { name = "psycopg", extras = ["pool", "binary"], specifier = ">=3.1" },
     { name = "requests", specifier = ">=2.31.0" },
 ]
 
@@ -365,6 +367,67 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8f/9a/7233bdd320841af2df067eedd7871ebe489681060ab7fb75e6afa24102fa/problog-2.2.9.tar.gz", hash = "sha256:c347597a07c4a1a4aee4fc4e674b34d55d4952e94e58ee81f3477146739b90f0", size = 1563609, upload-time = "2025-09-23T09:13:32.508Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a1/77/6fd9d6a4e7ff252bc0acdebeba6de337598dbd46c541a294f24e9fb67d42/problog-2.2.9-py3-none-any.whl", hash = "sha256:c4c765e487ff4ff515d22d07a02b6a61cc5f15b95be521252c6b30564f8f1822", size = 1965874, upload-time = "2025-09-23T09:13:30.636Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/b6/379d0a960f8f435ec78720462fd94c4863e7a31237cf81bf76d0af5883bf/psycopg-3.3.3.tar.gz", hash = "sha256:5e9a47458b3c1583326513b2556a2a9473a1001a56c9efe9e587245b43148dd9", size = 165624, upload-time = "2026-02-18T16:52:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/5b/181e2e3becb7672b502f0ed7f16ed7352aca7c109cfb94cf3878a9186db9/psycopg-3.3.3-py3-none-any.whl", hash = "sha256:f96525a72bcfade6584ab17e89de415ff360748c766f0106959144dcbb38c698", size = 212768, upload-time = "2026-02-18T16:46:27.365Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+pool = [
+    { name = "psycopg-pool" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/0a/cac9fdf1df16a269ba0e5f0f06cac61f826c94cadb39df028cdfe19d3a33/psycopg_binary-3.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:05f32239aec25c5fb15f7948cffdc2dc0dac098e48b80a140e4ba32b572a2e7d", size = 4590414, upload-time = "2026-02-18T16:50:01.441Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/c0/d8f8508fbf440edbc0099b1abff33003cd80c9e66eb3a1e78834e3fb4fb9/psycopg_binary-3.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7c84f9d214f2d1de2fafebc17fa68ac3f6561a59e291553dfc45ad299f4898c1", size = 4669021, upload-time = "2026-02-18T16:50:08.803Z" },
+    { url = "https://files.pythonhosted.org/packages/04/05/097016b77e343b4568feddf12c72171fc513acef9a4214d21b9478569068/psycopg_binary-3.3.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e77957d2ba17cada11be09a5066d93026cdb61ada7c8893101d7fe1c6e1f3925", size = 5467453, upload-time = "2026-02-18T16:50:14.985Z" },
+    { url = "https://files.pythonhosted.org/packages/91/23/73244e5feb55b5ca109cede6e97f32ef45189f0fdac4c80d75c99862729d/psycopg_binary-3.3.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:42961609ac07c232a427da7c87a468d3c82fee6762c220f38e37cfdacb2b178d", size = 5151135, upload-time = "2026-02-18T16:50:24.82Z" },
+    { url = "https://files.pythonhosted.org/packages/11/49/5309473b9803b207682095201d8708bbc7842ddf3f192488a69204e36455/psycopg_binary-3.3.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae07a3114313dd91fce686cab2f4c44af094398519af0e0f854bc707e1aeedf1", size = 6737315, upload-time = "2026-02-18T16:50:35.106Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/5d/03abe74ef34d460b33c4d9662bf6ec1dd38888324323c1a1752133c10377/psycopg_binary-3.3.3-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d257c58d7b36a621dcce1d01476ad8b60f12d80eb1406aee4cf796f88b2ae482", size = 4979783, upload-time = "2026-02-18T16:50:42.067Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/6c/3fbf8e604e15f2f3752900434046c00c90bb8764305a1b81112bff30ba24/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:07c7211f9327d522c9c47560cae00a4ecf6687f4e02d779d035dd3177b41cb12", size = 4509023, upload-time = "2026-02-18T16:50:50.116Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6b/1a06b43b7c7af756c80b67eac8bfaa51d77e68635a8a8d246e4f0bb7604a/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:8e7e9eca9b363dbedeceeadd8be97149d2499081f3c52d141d7cd1f395a91f83", size = 4185874, upload-time = "2026-02-18T16:50:55.97Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d3/bf49e3dcaadba510170c8d111e5e69e5ae3f981c1554c5bb71c75ce354bb/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:cb85b1d5702877c16f28d7b92ba030c1f49ebcc9b87d03d8c10bf45a2f1c7508", size = 3925668, upload-time = "2026-02-18T16:51:03.299Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/92/0aac830ed6a944fe334404e1687a074e4215630725753f0e3e9a9a595b62/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4d4606c84d04b80f9138d72f1e28c6c02dc5ae0c7b8f3f8aaf89c681ce1cd1b1", size = 4234973, upload-time = "2026-02-18T16:51:09.097Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/96/102244653ee5a143ece5afe33f00f52fe64e389dfce8dbc87580c6d70d3d/psycopg_binary-3.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:74eae563166ebf74e8d950ff359be037b85723d99ca83f57d9b244a871d6c13b", size = 3551342, upload-time = "2026-02-18T16:51:13.892Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/71/7a57e5b12275fe7e7d84d54113f0226080423a869118419c9106c083a21c/psycopg_binary-3.3.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:497852c5eaf1f0c2d88ab74a64a8097c099deac0c71de1cbcf18659a8a04a4b2", size = 4607368, upload-time = "2026-02-18T16:51:19.295Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/04/cb834f120f2b2c10d4003515ef9ca9d688115b9431735e3936ae48549af8/psycopg_binary-3.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:258d1ea53464d29768bf25930f43291949f4c7becc706f6e220c515a63a24edd", size = 4687047, upload-time = "2026-02-18T16:51:23.84Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e9/47a69692d3da9704468041aa5ed3ad6fc7f6bb1a5ae788d261a26bbca6c7/psycopg_binary-3.3.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:111c59897a452196116db12e7f608da472fbff000693a21040e35fc978b23430", size = 5487096, upload-time = "2026-02-18T16:51:29.645Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b6/0e0dd6a2f802864a4ae3dbadf4ec620f05e3904c7842b326aafc43e5f464/psycopg_binary-3.3.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:17bb6600e2455993946385249a3c3d0af52cd70c1c1cdbf712e9d696d0b0bf1b", size = 5168720, upload-time = "2026-02-18T16:51:36.499Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/0d/977af38ac19a6b55d22dff508bd743fd7c1901e1b73657e7937c7cccb0a3/psycopg_binary-3.3.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:642050398583d61c9856210568eb09a8e4f2fe8224bf3be21b67a370e677eead", size = 6762076, upload-time = "2026-02-18T16:51:43.167Z" },
+    { url = "https://files.pythonhosted.org/packages/34/40/912a39d48322cf86895c0eaf2d5b95cb899402443faefd4b09abbba6b6e1/psycopg_binary-3.3.3-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:533efe6dc3a7cba5e2a84e38970786bb966306863e45f3db152007e9f48638a6", size = 4997623, upload-time = "2026-02-18T16:51:47.707Z" },
+    { url = "https://files.pythonhosted.org/packages/98/0c/c14d0e259c65dc7be854d926993f151077887391d5a081118907a9d89603/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:5958dbf28b77ce2033482f6cb9ef04d43f5d8f4b7636e6963d5626f000efb23e", size = 4532096, upload-time = "2026-02-18T16:51:51.421Z" },
+    { url = "https://files.pythonhosted.org/packages/39/21/8b7c50a194cfca6ea0fd4d1f276158307785775426e90700ab2eba5cd623/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a6af77b6626ce92b5817bf294b4d45ec1a6161dba80fc2d82cdffdd6814fd023", size = 4208884, upload-time = "2026-02-18T16:51:57.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2c/a4981bf42cf30ebba0424971d7ce70a222ae9b82594c42fc3f2105d7b525/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:47f06fcbe8542b4d96d7392c476a74ada521c5aebdb41c3c0155f6595fc14c8d", size = 3944542, upload-time = "2026-02-18T16:52:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e9/b7c29b56aa0b85a4e0c4d89db691c1ceef08f46a356369144430c155a2f5/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e7800e6c6b5dc4b0ca7cc7370f770f53ac83886b76afda0848065a674231e856", size = 4254339, upload-time = "2026-02-18T16:52:10.444Z" },
+    { url = "https://files.pythonhosted.org/packages/98/5a/291d89f44d3820fffb7a04ebc8f3ef5dda4f542f44a5daea0c55a84abf45/psycopg_binary-3.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:165f22ab5a9513a3d7425ffb7fcc7955ed8ccaeef6d37e369d6cc1dff1582383", size = 3652796, upload-time = "2026-02-18T16:52:14.02Z" },
+]
+
+[[package]]
+name = "psycopg-pool"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/9a/9470d013d0d50af0da9c4251614aeb3c1823635cab3edc211e3839db0bcf/psycopg_pool-3.3.0.tar.gz", hash = "sha256:fa115eb2860bd88fce1717d75611f41490dec6135efb619611142b24da3f6db5", size = 31606, upload-time = "2025-12-01T11:34:33.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c3/26b8a0908a9db249de3b4169692e1c7c19048a9bc41a4d3209cee7dbb758/psycopg_pool-3.3.0-py3-none-any.whl", hash = "sha256:2e44329155c410b5e8666372db44276a8b1ebd8c90f1c3026ebba40d4bc81063", size = 39995, upload-time = "2025-12-01T11:34:29.761Z" },
 ]
 
 [[package]]
@@ -528,6 +591,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/08/d5/655beb51224d1bfd4f9ddc0bb209659bfe71ff141bcf05c418ab670698f0/ty-0.0.14-py3-none-win32.whl", hash = "sha256:b20e22cf54c66b3e37e87377635da412d9a552c9bf4ad9fc449fed8b2e19dad2", size = 9507626, upload-time = "2026-01-27T00:57:41.43Z" },
     { url = "https://files.pythonhosted.org/packages/b6/d9/c569c9961760e20e0a4bc008eeb1415754564304fd53997a371b7cf3f864/ty-0.0.14-py3-none-win_amd64.whl", hash = "sha256:e312ff9475522d1a33186657fe74d1ec98e4a13e016d66f5758a452c90ff6409", size = 10437980, upload-time = "2026-01-27T00:57:36.422Z" },
     { url = "https://files.pythonhosted.org/packages/ad/0c/186829654f5bfd9a028f6648e9caeb11271960a61de97484627d24443f91/ty-0.0.14-py3-none-win_arm64.whl", hash = "sha256:b6facdbe9b740cb2c15293a1d178e22ffc600653646452632541d01c36d5e378", size = 9885831, upload-time = "2026-01-27T00:57:49.747Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2025.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add load_from_db() using Postgres + AcousticBrainz with tqdm progress
- Add parquet cache for training examples
- Fix _train_cv() per-class metrics bug (was returning zeros)
- Fix hardcoded DATA_DIR (now uses AB_DATA_DIR env var)
- Add --from-db, --synthetic, --data-dir CLI flags
- Update README with full architecture and all modules
- Add module4 CHANGELOG and USAGE docs